### PR TITLE
feat: add state machine extensions for ICAC exploitation lifecycle modeling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,49 @@ All notable changes to the CAC ontology family will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
 
+### Added - CaseLinker State Machine Extensions
+
+Adds four offense-trajectory constructs for state-machine mapping (phases as states, transitions as typed events). Grounded in sextortion, production, and cross-platform offense patterns.
+
+#### Sextortion module (`cacontology-sextortion`)
+
+- `cacontology-sextortion:CoercionCycle` — self-sustaining leverage loop (subClassOf `cac-core:Situation`, `cac-core:ExploitationEvent`)
+- `cacontology-sextortion:sustainedBy` — retained leverage artifact powering the cycle
+- `cacontology-sextortion:cyclesBetween` — phase instances forming the loop
+- `cacontology-sextortion:coercionCycleDemandType` — cycle demand enum (`imagery_quota`, `live_conduct`, `financial`, `victim_recruitment`); separate from `ExtortionDemand.demandType` to preserve existing semantics
+- `cacontology-sextortion:terminationCondition` — cycle end condition enum
+- `cacontology-sextortion:CoercionCycleShape` in `cacontology-sextortion-shapes.ttl`
+
+#### Platforms module (`cacontology-platforms`)
+
+- `cacontology-platforms:PlatformAffordance` taxonomy: `Anonymity`, `Ephemerality`, `UnmonitoredCommunication`, `ContactDiscovery`, `DistributionInfrastructure`, `GenerativeSynthesis`, `Coordination`, `CoercionLeverage`
+- `cacontology-platforms:ChannelMigrationEvent` — cross-platform contact migration with `fromPlatform`, `toPlatform`, `migrationRationale`, `occursBetween`
+- `cacontology-platforms:AffordanceMisuse` — transition-level affordance annotation with `affordanceClass`, `enablesTransitionFrom`, `enablesTransitionTo`, `platform`, `misuseDescription`
+- `ChannelMigrationEventShape`, `AffordanceMisuseShape` in `cacontology-platforms-shapes.ttl`
+
+#### Grooming module (`cacontology-grooming`)
+
+- `cacontology-grooming:AccountReplacementEvent` — post-ban/block account reset with `triggeredBy`, `resumesAt`, `originalAccountId`, `replacementAccountId`
+- `AccountReplacementEventShape` in `cacontology-grooming-shapes.ttl`
+
+#### Examples, queries, contexts, and developer bindings
+
+- `examples_knowledge_graphs/caselinker-state-machine-extensions-example.ttl` — CoercionCycle, ChannelMigrationEvent, AffordanceMisuse
+- `examples_knowledge_graphs/caselinker-account-replacement-example.ttl` — AccountReplacementEvent (separate file for grooming SHACL cross-validation)
+- `examples_knowledge_graphs/jsonld/*-example.jsonld` — one JSON-LD document per new class
+- `contexts/cacontology-sextortion.jsonld`, `contexts/cacontology-platforms.jsonld`, `contexts/cacontology-grooming.jsonld` — per-module JSON-LD contexts
+- `contexts/cacontology-state-machine-extensions.jsonld` — combined JSON-LD context for all four classes
+- `example_SPARQL_queries/caselinker-state-machine-analytics.rq`
+- `sdk/python/cacontology/` — optional Python dataclass bindings (`CoercionCycle`, `ChannelMigrationEvent`, `AffordanceMisuse`, `AccountReplacementEvent`)
+- `testing/test_state_machine_extensions.py` — SHACL pass/fail unit tests (8 tests)
+- `testing/shacl_validation.py` — domain cross-checks for new example graphs
+
+#### Core / semantic spine (`cacontology-core-spine`, `cacontology-core-shapes`)
+
+- Clarify existing `cac-core:precedes` for phase sequencing in state machine traversal (`rdfs:isDefinedBy`, updated `rdfs:comment` in `ontology/cacontology-core-spine.ttl`; not a new property)
+- `PhasePrecedesShape` and `PrecedesPropertyShape` in `ontology/cacontology-core-shapes.ttl`
 
 ## v3.0.0 - 16 March 2026
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,7 @@ Adds four offense-trajectory constructs for state-machine mapping (phases as sta
 
 #### Core / semantic spine (`cacontology-core-spine`, `cacontology-core-shapes`)
 
-- Clarify existing `cac-core:precedes` for phase sequencing in state machine traversal (`rdfs:isDefinedBy`, updated `rdfs:comment` in `ontology/cacontology-core-spine.ttl`; not a new property)
+- **New** `cac-core:precedes` — spine-level phase sequencing for offense-trajectory state machines (`rdfs:domain` / `rdfs:range` `cac-core:Phase`; defined in `ontology/cacontology-core-spine.ttl`). Not present on main before this branch. Distinct from pre-existing module-local ordering properties (`cacontology:transitionsTo`, `cacontology-temporal:temporallyPrecedes`, `cacontology-usa-federal:precedesPhase`). UCO and CASE imported ontologies do not define an equivalent property.
 - `PhasePrecedesShape` and `PrecedesPropertyShape` in `ontology/cacontology-core-shapes.ttl`
 
 ## v3.0.0 - 16 March 2026

--- a/contexts/cacontology-grooming.jsonld
+++ b/contexts/cacontology-grooming.jsonld
@@ -1,0 +1,31 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "@vocab": "https://cacontology.projectvic.org/grooming#",
+    "cacontology": "https://cacontology.projectvic.org#",
+    "cacontology-grooming": "https://cacontology.projectvic.org/grooming#",
+    "cac-core": "https://cacontology.projectvic.org/core#",
+    "uco": "https://ontology.unifiedcyberontology.org/uco/core#",
+    "AccountReplacementEvent": {
+      "@id": "cacontology-grooming:AccountReplacementEvent",
+      "@type": "@id"
+    },
+    "triggeredBy": "cacontology-grooming:triggeredBy",
+    "resumesAt": {
+      "@id": "cacontology-grooming:resumesAt",
+      "@type": "@id"
+    },
+    "originalAccountId": {
+      "@id": "cacontology-grooming:originalAccountId",
+      "@type": "@id"
+    },
+    "replacementAccountId": {
+      "@id": "cacontology-grooming:replacementAccountId",
+      "@type": "@id"
+    },
+    "precedes": {
+      "@id": "cac-core:precedes",
+      "@type": "@id"
+    }
+  }
+}

--- a/contexts/cacontology-platforms.jsonld
+++ b/contexts/cacontology-platforms.jsonld
@@ -1,0 +1,88 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "@vocab": "https://cacontology.projectvic.org/platforms#",
+    "cacontology": "https://cacontology.projectvic.org#",
+    "cacontology-platforms": "https://cacontology.projectvic.org/platforms#",
+    "cac-core": "https://cacontology.projectvic.org/core#",
+    "uco": "https://ontology.unifiedcyberontology.org/uco/core#",
+    "ChannelMigrationEvent": {
+      "@id": "cacontology-platforms:ChannelMigrationEvent",
+      "@type": "@id"
+    },
+    "AffordanceMisuse": {
+      "@id": "cacontology-platforms:AffordanceMisuse",
+      "@type": "@id"
+    },
+    "PlatformAffordance": {
+      "@id": "cacontology-platforms:PlatformAffordance",
+      "@type": "@id"
+    },
+    "Anonymity": {
+      "@id": "cacontology-platforms:Anonymity",
+      "@type": "@id"
+    },
+    "Ephemerality": {
+      "@id": "cacontology-platforms:Ephemerality",
+      "@type": "@id"
+    },
+    "UnmonitoredCommunication": {
+      "@id": "cacontology-platforms:UnmonitoredCommunication",
+      "@type": "@id"
+    },
+    "ContactDiscovery": {
+      "@id": "cacontology-platforms:ContactDiscovery",
+      "@type": "@id"
+    },
+    "DistributionInfrastructure": {
+      "@id": "cacontology-platforms:DistributionInfrastructure",
+      "@type": "@id"
+    },
+    "GenerativeSynthesis": {
+      "@id": "cacontology-platforms:GenerativeSynthesis",
+      "@type": "@id"
+    },
+    "Coordination": {
+      "@id": "cacontology-platforms:Coordination",
+      "@type": "@id"
+    },
+    "CoercionLeverage": {
+      "@id": "cacontology-platforms:CoercionLeverage",
+      "@type": "@id"
+    },
+    "fromPlatform": {
+      "@id": "cacontology-platforms:fromPlatform",
+      "@type": "@id"
+    },
+    "toPlatform": {
+      "@id": "cacontology-platforms:toPlatform",
+      "@type": "@id"
+    },
+    "migrationRationale": "cacontology-platforms:migrationRationale",
+    "occursBetween": {
+      "@id": "cacontology-platforms:occursBetween",
+      "@type": "@id"
+    },
+    "affordanceClass": {
+      "@id": "cacontology-platforms:affordanceClass",
+      "@type": "@id"
+    },
+    "enablesTransitionFrom": {
+      "@id": "cacontology-platforms:enablesTransitionFrom",
+      "@type": "@id"
+    },
+    "enablesTransitionTo": {
+      "@id": "cacontology-platforms:enablesTransitionTo",
+      "@type": "@id"
+    },
+    "platform": {
+      "@id": "cacontology-platforms:platform",
+      "@type": "@id"
+    },
+    "misuseDescription": "cacontology-platforms:misuseDescription",
+    "precedes": {
+      "@id": "cac-core:precedes",
+      "@type": "@id"
+    }
+  }
+}

--- a/contexts/cacontology-sextortion.jsonld
+++ b/contexts/cacontology-sextortion.jsonld
@@ -1,0 +1,28 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "@vocab": "https://cacontology.projectvic.org/sextortion#",
+    "cacontology": "https://cacontology.projectvic.org#",
+    "cacontology-sextortion": "https://cacontology.projectvic.org/sextortion#",
+    "cac-core": "https://cacontology.projectvic.org/core#",
+    "uco": "https://ontology.unifiedcyberontology.org/uco/core#",
+    "CoercionCycle": {
+      "@id": "cacontology-sextortion:CoercionCycle",
+      "@type": "@id"
+    },
+    "sustainedBy": {
+      "@id": "cacontology-sextortion:sustainedBy",
+      "@type": "@id"
+    },
+    "cyclesBetween": {
+      "@id": "cacontology-sextortion:cyclesBetween",
+      "@type": "@id"
+    },
+    "coercionCycleDemandType": "cacontology-sextortion:coercionCycleDemandType",
+    "terminationCondition": "cacontology-sextortion:terminationCondition",
+    "precedes": {
+      "@id": "cac-core:precedes",
+      "@type": "@id"
+    }
+  }
+}

--- a/contexts/cacontology-state-machine-extensions.jsonld
+++ b/contexts/cacontology-state-machine-extensions.jsonld
@@ -1,0 +1,31 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "cac-sextortion": "https://cacontology.projectvic.org/sextortion#",
+    "cac-platforms": "https://cacontology.projectvic.org/platforms#",
+    "cac-grooming": "https://cacontology.projectvic.org/grooming#",
+    "cac-core": "https://cacontology.projectvic.org/core#",
+    "uco": "https://ontology.unifiedcyberontology.org/uco/core#",
+    "CoercionCycle": "cac-sextortion:CoercionCycle",
+    "ChannelMigrationEvent": "cac-platforms:ChannelMigrationEvent",
+    "AffordanceMisuse": "cac-platforms:AffordanceMisuse",
+    "AccountReplacementEvent": "cac-grooming:AccountReplacementEvent",
+    "sustainedBy": { "@id": "cac-sextortion:sustainedBy", "@type": "@id" },
+    "cyclesBetween": { "@id": "cac-sextortion:cyclesBetween", "@type": "@id" },
+    "coercionCycleDemandType": "cac-sextortion:coercionCycleDemandType",
+    "terminationCondition": "cac-sextortion:terminationCondition",
+    "fromPlatform": { "@id": "cac-platforms:fromPlatform", "@type": "@id" },
+    "toPlatform": { "@id": "cac-platforms:toPlatform", "@type": "@id" },
+    "migrationRationale": "cac-platforms:migrationRationale",
+    "occursBetween": { "@id": "cac-platforms:occursBetween", "@type": "@id" },
+    "affordanceClass": { "@id": "cac-platforms:affordanceClass", "@type": "@id" },
+    "enablesTransitionFrom": { "@id": "cac-platforms:enablesTransitionFrom", "@type": "@id" },
+    "enablesTransitionTo": { "@id": "cac-platforms:enablesTransitionTo", "@type": "@id" },
+    "platform": { "@id": "cac-platforms:platform", "@type": "@id" },
+    "misuseDescription": "cac-platforms:misuseDescription",
+    "triggeredBy": "cac-grooming:triggeredBy",
+    "resumesAt": { "@id": "cac-grooming:resumesAt", "@type": "@id" },
+    "originalAccountId": { "@id": "cac-grooming:originalAccountId", "@type": "@id" },
+    "replacementAccountId": { "@id": "cac-grooming:replacementAccountId", "@type": "@id" }
+  }
+}

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -68,8 +68,10 @@ The stable top-level class hierarchy introduced in v3.0.0 (`cac-core:` namespace
 - **ProductionOffense**: Child sexual abuse material production activity
 - **CustodialRelationship**: Trust relationship involving authority over children
 - **GroomingSolicitation**: Grooming or solicitation of children for sexual purposes
+- **AccountReplacementEvent** (`cacontology-grooming:AccountReplacementEvent`): Offender creates a new account after ban or block and resumes at an earlier grooming phase (typically `InitialContactPhase`); lifecycle reset, not a coercion loop
 - **SexualConsequenceGameGrooming**: Physical-space, multi-victim grooming pattern where a perpetrator uses structured “games with sexual consequences” involving several juveniles
 - **Sextortion**: Sexual extortion incidents involving children
+- **CoercionCycle** (`cacontology-sextortion:CoercionCycle`): Self-sustaining sextortion loop where retained imagery is redeployed as perpetual leverage; distinct from linear `progressionStage` or single `ExtortionDemand` events
 - **LiveStreamingCSA**: Live streaming of child sexual abuse
 - **DigitallyGeneratedCSAMIncident**: AI-generated or manipulated CSAM
 
@@ -122,6 +124,9 @@ The stable top-level class hierarchy introduced in v3.0.0 (`cac-core:` namespace
 - **PhotoDNAHash**: Microsoft PhotoDNA hash value for image matching
 - **DetectionResult**: Outcome of automated content analysis
 - **SocialMediaPlatform**: Online platform used for communication or content sharing
+- **ChannelMigrationEvent** (`cacontology-platforms:ChannelMigrationEvent`): Deliberate move of contact from one platform to another before escalation (capability upgrade and/or evidence trail severance)
+- **PlatformAffordance** (`cacontology-platforms:PlatformAffordance`): Platform capability taxonomy (Anonymity, Ephemerality, UnmonitoredCommunication, etc.) usable for transition-level annotation
+- **AffordanceMisuse** (`cacontology-platforms:AffordanceMisuse`): Links a platform affordance to the phase transition it enabled (affordances on offense edges, not platform nodes alone)
 - **ContentModerationCapability**: Platform's ability to detect and remove illegal content
 
 ### Athletic Coaching Roles
@@ -133,6 +138,14 @@ The stable top-level class hierarchy introduced in v3.0.0 (`cac-core:` namespace
 
 ### Properties
 - **reportedBy**: Links a report to its reporter
+- **cac-core:precedes**: Temporal ordering property linking a Phase instance to the Phase that follows it in the documented offense lifecycle (canonical definition in `cacontology-core-spine.ttl`)
+- **sustainedBy** (`cacontology-sextortion:sustainedBy`): Links a coercion cycle to retained leverage material
+- **cyclesBetween** (`cacontology-sextortion:cyclesBetween`): Links a coercion cycle to the phase instances forming the loop
+- **fromPlatform** / **toPlatform** (`cacontology-platforms:`): Originating and destination platforms for a channel migration event
+- **occursBetween** (`cacontology-platforms:occursBetween`): Phase instances separated by a channel migration or similar transition event
+- **affordanceClass** (`cacontology-platforms:affordanceClass`): Platform affordance category misused to enable a phase transition
+- **enablesTransitionFrom** / **enablesTransitionTo** (`cacontology-platforms:`): Source and target phases for affordance misuse
+- **resumesAt** (`cacontology-grooming:resumesAt`): Grooming phase the offender returns to after account replacement
 - **hasEvidence**: Links a report to its evidence
 - **triggersAction**: Links a report to actions taken
 - **performedBy**: Links an action to its performer

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -138,7 +138,7 @@ The stable top-level class hierarchy introduced in v3.0.0 (`cac-core:` namespace
 
 ### Properties
 - **reportedBy**: Links a report to its reporter
-- **cac-core:precedes**: Temporal ordering property linking a Phase instance to the Phase that follows it in the documented offense lifecycle (canonical definition in `cacontology-core-spine.ttl`)
+- **cac-core:precedes**: **New in CaseLinker state machine extensions.** Spine-level temporal ordering property linking one `cac-core:Phase` instance to the next in a documented offense lifecycle (`ontology/cacontology-core-spine.ttl`). Related but distinct from pre-existing properties: `cacontology:transitionsTo` (investigation phases in `cacontology-core.ttl`), `cacontology-temporal:temporallyPrecedes` (subPropertyOf `gufo:precedes`), and `cacontology-usa-federal:precedesPhase` (federal legal phases). Not defined in UCO or CASE.
 - **sustainedBy** (`cacontology-sextortion:sustainedBy`): Links a coercion cycle to retained leverage material
 - **cyclesBetween** (`cacontology-sextortion:cyclesBetween`): Links a coercion cycle to the phase instances forming the loop
 - **fromPlatform** / **toPlatform** (`cacontology-platforms:`): Originating and destination platforms for a channel migration event

--- a/docs/user_doc.md
+++ b/docs/user_doc.md
@@ -828,7 +828,7 @@ ORDER BY DESC(?violationCount)
 
 ## CaseLinker State Machine Extensions
 
-Four offense-trajectory classes support mapping extracted case features to a formal state machine (phases as states, typed events as transitions). Phase ordering uses existing `cac-core:precedes` (defined in `ontology/cacontology-core-spine.ttl`).
+Four offense-trajectory classes support mapping extracted case features to a formal state machine (phases as states, typed events as transitions). Phase ordering uses **`cac-core:precedes`**, introduced in this release in `ontology/cacontology-core-spine.ttl` (not present on main before the state-machine-extensions branch). It is spine-scoped to `cac-core:Phase` offense trajectories and is separate from earlier module-local ordering properties (`cacontology:transitionsTo`, `cacontology-temporal:temporallyPrecedes`, `cacontology-usa-federal:precedesPhase`).
 
 | Class / property | IRI |
 |------------------|-----|

--- a/docs/user_doc.md
+++ b/docs/user_doc.md
@@ -823,6 +823,69 @@ GROUP BY ?tier
 ORDER BY DESC(?violationCount)
 ```
 
+ORDER BY DESC(?violationCount)
+```
+
+## CaseLinker State Machine Extensions
+
+Four offense-trajectory classes support mapping extracted case features to a formal state machine (phases as states, typed events as transitions). Phase ordering uses existing `cac-core:precedes` (defined in `ontology/cacontology-core-spine.ttl`).
+
+| Class / property | IRI |
+|------------------|-----|
+| CoercionCycle | `https://cacontology.projectvic.org/sextortion#CoercionCycle` |
+| ChannelMigrationEvent | `https://cacontology.projectvic.org/platforms#ChannelMigrationEvent` |
+| AffordanceMisuse | `https://cacontology.projectvic.org/platforms#AffordanceMisuse` |
+| AccountReplacementEvent | `https://cacontology.projectvic.org/grooming#AccountReplacementEvent` |
+| precedes (phase sequencing) | `https://cacontology.projectvic.org/core#precedes` |
+
+### Example knowledge graph
+
+```bash
+pyshacl -s ontology/cacontology-sextortion-shapes.ttl \
+  -d examples_knowledge_graphs/caselinker-state-machine-extensions-example.ttl
+pyshacl -s ontology/cacontology-platforms-shapes.ttl \
+  -d examples_knowledge_graphs/caselinker-state-machine-extensions-example.ttl
+pyshacl -s ontology/cacontology-grooming-shapes.ttl \
+  -d examples_knowledge_graphs/caselinker-account-replacement-example.ttl
+```
+
+Reference instance files:
+- `examples_knowledge_graphs/caselinker-state-machine-extensions-example.ttl` (CoercionCycle, ChannelMigrationEvent, AffordanceMisuse)
+- `examples_knowledge_graphs/caselinker-account-replacement-example.ttl` (AccountReplacementEvent)
+
+Per-class JSON-LD examples: `examples_knowledge_graphs/jsonld/`
+
+JSON-LD contexts: `contexts/cacontology-sextortion.jsonld`, `contexts/cacontology-platforms.jsonld`, `contexts/cacontology-grooming.jsonld`, `contexts/cacontology-state-machine-extensions.jsonld`
+
+### SPARQL analytics
+
+```bash
+# Load both example graphs to query all four class types
+sparql --query example_SPARQL_queries/caselinker-state-machine-analytics.rq \
+  --data examples_knowledge_graphs/caselinker-state-machine-extensions-example.ttl \
+  --data examples_knowledge_graphs/caselinker-account-replacement-example.ttl
+```
+
+### Optional Python SDK
+
+```python
+from cacontology import CoercionCycle, ChannelMigrationEvent, AffordanceMisuse, AccountReplacementEvent
+
+cycle = CoercionCycle(
+    id="urn:uuid:...",
+    sustained_by="urn:uuid:...",
+    cycles_between=["urn:uuid:phase-a", "urn:uuid:phase-b"],
+    coercion_cycle_demand_type="imagery_quota",
+)
+graph = cycle.to_graph()  # serialize for RDF store import
+```
+
+Bindings live in `sdk/python/cacontology/`. Run unit tests:
+
+```bash
+python testing/test_state_machine_extensions.py
+```
+
 ## Validation and Quality Assurance
 
 ### 1. Using pySHACL ✅ **COMPREHENSIVE COVERAGE COMPLETED**

--- a/example_SPARQL_queries/caselinker-state-machine-analytics.rq
+++ b/example_SPARQL_queries/caselinker-state-machine-analytics.rq
@@ -1,0 +1,38 @@
+# Query: caselinker_state_machine_analytics
+# Purpose: List offense-trajectory state-machine nodes (CoercionCycle, ChannelMigrationEvent,
+#          AffordanceMisuse, AccountReplacementEvent) for CaseLinker graph review
+# Data: examples_knowledge_graphs/caselinker-state-machine-extensions-example.ttl
+#       examples_knowledge_graphs/caselinker-account-replacement-example.ttl
+# Security: TLP-RED content excluded by default
+
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX cacontology-sextortion: <https://cacontology.projectvic.org/sextortion#>
+PREFIX cacontology-platforms: <https://cacontology.projectvic.org/platforms#>
+PREFIX cacontology-grooming: <https://cacontology.projectvic.org/grooming#>
+PREFIX uco-confidentiality: <https://ontology.unifiedcyberontology.org/uco/confidentiality/>
+
+SELECT ?node ?nodeType ?label ?detail
+WHERE {
+    VALUES ?nodeType {
+        cacontology-sextortion:CoercionCycle
+        cacontology-platforms:ChannelMigrationEvent
+        cacontology-platforms:AffordanceMisuse
+        cacontology-grooming:AccountReplacementEvent
+    }
+    ?node a ?nodeType .
+    OPTIONAL { ?node rdfs:label ?label }
+    OPTIONAL {
+        ?node cacontology-sextortion:coercionCycleDemandType ?detail
+    }
+    OPTIONAL {
+        ?node cacontology-platforms:migrationRationale ?detail
+    }
+    OPTIONAL {
+        ?node cacontology-grooming:triggeredBy ?detail
+    }
+    FILTER NOT EXISTS {
+        ?node uco-confidentiality:TLP-RED ?whatever .
+    }
+}
+ORDER BY ?nodeType ?node

--- a/examples_knowledge_graphs/caselinker-account-replacement-example.ttl
+++ b/examples_knowledge_graphs/caselinker-account-replacement-example.ttl
@@ -1,0 +1,29 @@
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix uco-core: <https://ontology.unifiedcyberontology.org/uco/core/> .
+@prefix uco-observable: <https://ontology.unifiedcyberontology.org/uco/observable/> .
+@prefix cacontology-grooming: <https://cacontology.projectvic.org/grooming#> .
+
+# Account replacement only — validates against grooming shapes without
+# cross-module Phase typing conflicts from sextortion phase nodes.
+
+<urn:uuid:45678901-cdef-0123-4567-89abcdef0123> rdf:type uco-observable:Account ;
+    rdfs:label "Banned Production Account"@en ;
+    uco-core:description "Platform-banned account used for initial victim contact on messaging service." .
+
+<urn:uuid:56789012-def0-1234-5678-9abcdef01234> rdf:type uco-observable:Account ;
+    rdfs:label "Replacement Account"@en ;
+    uco-core:description "New account created after platform ban to resume contact with victims." .
+
+<urn:uuid:67890123-ef01-2345-6789-abcdef012345> rdf:type cacontology-grooming:InitialContactPhase ,
+        cacontology-grooming:GroomingPhase ;
+    rdfs:label "Resumed Initial Contact"@en ;
+    uco-core:description "Offender returned to initial contact phase using replacement account." .
+
+<urn:uuid:78901234-f012-3456-789a-bcdef0123456> rdf:type cacontology-grooming:AccountReplacementEvent ;
+    rdfs:label "Post-Ban Account Replacement"@en ;
+    uco-core:description "Offender created new account after platform ban and resumed grooming at initial contact." ;
+    cacontology-grooming:triggeredBy "platform_ban" ;
+    cacontology-grooming:resumesAt <urn:uuid:67890123-ef01-2345-6789-abcdef012345> ;
+    cacontology-grooming:originalAccountId <urn:uuid:45678901-cdef-0123-4567-89abcdef0123> ;
+    cacontology-grooming:replacementAccountId <urn:uuid:56789012-def0-1234-5678-9abcdef01234> .

--- a/examples_knowledge_graphs/caselinker-state-machine-extensions-example.ttl
+++ b/examples_knowledge_graphs/caselinker-state-machine-extensions-example.ttl
@@ -1,0 +1,83 @@
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix uco-core: <https://ontology.unifiedcyberontology.org/uco/core/> .
+@prefix uco-observable: <https://ontology.unifiedcyberontology.org/uco/observable/> .
+@prefix cac-core: <https://cacontology.projectvic.org/core#> .
+@prefix cacontology-sextortion: <https://cacontology.projectvic.org/sextortion#> .
+@prefix cacontology-platforms: <https://cacontology.projectvic.org/platforms#> .
+@prefix cacontology-grooming: <https://cacontology.projectvic.org/grooming#> .
+
+# =============================================================================
+# CaseLinker State Machine Extension Examples
+# Grounded in WA sextortion (coercion cycle, channel migration, affordance misuse)
+# and production-style account replacement after platform ban.
+# =============================================================================
+
+# --- Shared platforms (Instagram DM → Messenger pattern) ---
+# Typed as DigitalService only to avoid full SocialMediaPlatform/MessagingService
+# shape requirements in this focused state-machine example.
+<urn:uuid:a1b2c3d4-e5f6-7890-abcd-ef1234567890> rdf:type uco-observable:DigitalService ;
+    rdfs:label "Instagram"@en ;
+    uco-core:name "Instagram" ;
+    uco-core:description "Initial contact platform in sextortion case with public-profile DM entry point." .
+
+<urn:uuid:b2c3d4e5-f6a7-8901-bcde-f12345678901> rdf:type uco-observable:DigitalService ;
+    rdfs:label "Facebook Messenger"@en ;
+    uco-core:name "Facebook Messenger" ;
+    uco-core:description "Destination platform with live video capability used after migration from Instagram." .
+
+# --- WA sextortion phases (from wa-sextortion-case-example pattern) ---
+<urn:uuid:c3d4e5f6-a7b8-9012-cdef-123456789012> rdf:type cacontology-sextortion:ImageAcquisitionPhase ,
+        cac-core:Phase ;
+    rdfs:label "Image Acquisition Phase"@en ;
+    cacontology-sextortion:progressionStage 4 .
+
+<urn:uuid:d4e5f6a7-b8c9-0123-def0-234567890123> rdf:type cacontology-sextortion:ExtortionPhase ,
+        cac-core:Phase ;
+    rdfs:label "Extortion Phase"@en ;
+    cacontology-sextortion:progressionStage 5 .
+
+<urn:uuid:e5f6a7b8-c9d0-1234-ef01-345678901234> rdf:type cacontology-sextortion:TrustBuildingPhase ,
+        cac-core:Phase ;
+    rdfs:label "Trust Building Phase"@en ;
+    cacontology-sextortion:progressionStage 2 .
+
+# --- Retained leverage material ---
+<urn:uuid:f6a7b8c9-d0e1-2345-f012-456789012345> rdf:type uco-observable:Image, cac-core:Artifact ;
+    rdfs:label "Retained Intimate Image Set"@en ;
+    uco-core:description "Intimate images retained by offender and redeployed across multiple coercion iterations." .
+
+# GAP 1: CoercionCycle
+<urn:uuid:01234567-89ab-cdef-0123-456789abcdef> rdf:type cacontology-sextortion:CoercionCycle ;
+    rdfs:label "WA Sextortion Coercion Cycle"@en ;
+    uco-core:description "Self-sustaining loop: offender redeploys retained images to demand additional content after initial extortion." ;
+    cacontology-sextortion:sustainedBy <urn:uuid:f6a7b8c9-d0e1-2345-f012-456789012345> ;
+    cacontology-sextortion:cyclesBetween <urn:uuid:d4e5f6a7-b8c9-0123-def0-234567890123> ,
+                                       <urn:uuid:c3d4e5f6-a7b8-9012-cdef-123456789012> ;
+    cacontology-sextortion:coercionCycleDemandType "imagery_quota" ;
+    cacontology-sextortion:terminationCondition "apprehension" .
+
+# GAP 2: ChannelMigrationEvent
+<urn:uuid:12345678-9abc-def0-1234-56789abcdef0> rdf:type cacontology-platforms:ChannelMigrationEvent ;
+    rdfs:label "Instagram to Messenger Migration"@en ;
+    uco-core:description "Offender moved victim from Instagram DMs to Messenger before escalating to live video demands." ;
+    cacontology-platforms:fromPlatform <urn:uuid:a1b2c3d4-e5f6-7890-abcd-ef1234567890> ;
+    cacontology-platforms:toPlatform <urn:uuid:b2c3d4e5-f6a7-8901-bcde-f12345678901> ;
+    cacontology-platforms:migrationRationale "both" ;
+    cacontology-platforms:occursBetween <urn:uuid:e5f6a7b8-c9d0-1234-ef01-345678901234> ,
+                                        <urn:uuid:c3d4e5f6-a7b8-9012-cdef-123456789012> .
+
+# GAP 3: AffordanceMisuse
+<urn:uuid:23456789-abcd-ef01-2345-6789abcdef01> rdf:type cacontology-platforms:Ephemerality ,
+        cacontology-platforms:PlatformAffordance .
+
+<urn:uuid:34567890-bcde-f012-3456-789abcdef012> rdf:type cacontology-platforms:AffordanceMisuse ;
+    rdfs:label "Ephemeral Messaging Enabled Escalation"@en ;
+    cacontology-platforms:affordanceClass <urn:uuid:23456789-abcd-ef01-2345-6789abcdef01> ;
+    cacontology-platforms:enablesTransitionFrom <urn:uuid:e5f6a7b8-c9d0-1234-ef01-345678901234> ;
+    cacontology-platforms:enablesTransitionTo <urn:uuid:c3d4e5f6-a7b8-9012-cdef-123456789012> ;
+    cacontology-platforms:platform <urn:uuid:a1b2c3d4-e5f6-7890-abcd-ef1234567890> ;
+    cacontology-platforms:misuseDescription "Offender used disappearing-message affordance to normalize image sharing before extortion phase." .
+
+# GAP 4 (AccountReplacementEvent) — see caselinker-account-replacement-example.ttl

--- a/examples_knowledge_graphs/jsonld/account-replacement-event-example.jsonld
+++ b/examples_knowledge_graphs/jsonld/account-replacement-event-example.jsonld
@@ -1,0 +1,13 @@
+{
+  "@context": {
+    "cac-grooming": "https://cacontology.projectvic.org/grooming#",
+    "uco": "https://ontology.unifiedcyberontology.org/uco/core#"
+  },
+  "@id": "urn:uuid:78901234-f012-3456-789a-bcdef0123456",
+  "@type": "cac-grooming:AccountReplacementEvent",
+  "uco:description": "Offender created new account after platform ban and resumed grooming at initial contact.",
+  "cac-grooming:triggeredBy": "platform_ban",
+  "cac-grooming:resumesAt": { "@id": "urn:uuid:67890123-ef01-2345-6789-abcdef012345" },
+  "cac-grooming:originalAccountId": { "@id": "urn:uuid:45678901-cdef-0123-4567-89abcdef0123" },
+  "cac-grooming:replacementAccountId": { "@id": "urn:uuid:56789012-def0-1234-5678-9abcdef01234" }
+}

--- a/examples_knowledge_graphs/jsonld/affordance-misuse-example.jsonld
+++ b/examples_knowledge_graphs/jsonld/affordance-misuse-example.jsonld
@@ -1,0 +1,12 @@
+{
+  "@context": {
+    "cac-platforms": "https://cacontology.projectvic.org/platforms#"
+  },
+  "@id": "urn:uuid:34567890-bcde-f012-3456-789abcdef012",
+  "@type": "cac-platforms:AffordanceMisuse",
+  "cac-platforms:affordanceClass": { "@id": "urn:uuid:23456789-abcd-ef01-2345-6789abcdef01", "@type": "cac-platforms:Ephemerality" },
+  "cac-platforms:enablesTransitionFrom": { "@id": "urn:uuid:e5f6a7b8-c9d0-1234-ef01-345678901234" },
+  "cac-platforms:enablesTransitionTo": { "@id": "urn:uuid:c3d4e5f6-a7b8-9012-cdef-123456789012" },
+  "cac-platforms:platform": { "@id": "urn:uuid:a1b2c3d4-e5f6-7890-abcd-ef1234567890" },
+  "cac-platforms:misuseDescription": "Offender used disappearing-message affordance to normalize image sharing before extortion."
+}

--- a/examples_knowledge_graphs/jsonld/channel-migration-event-example.jsonld
+++ b/examples_knowledge_graphs/jsonld/channel-migration-event-example.jsonld
@@ -1,0 +1,16 @@
+{
+  "@context": {
+    "cac-platforms": "https://cacontology.projectvic.org/platforms#",
+    "uco": "https://ontology.unifiedcyberontology.org/uco/core#"
+  },
+  "@id": "urn:uuid:12345678-9abc-def0-1234-56789abcdef0",
+  "@type": "cac-platforms:ChannelMigrationEvent",
+  "uco:description": "Offender moved victim from Instagram DMs to Messenger before escalating.",
+  "cac-platforms:fromPlatform": { "@id": "urn:uuid:a1b2c3d4-e5f6-7890-abcd-ef1234567890" },
+  "cac-platforms:toPlatform": { "@id": "urn:uuid:b2c3d4e5-f6a7-8901-bcde-f12345678901" },
+  "cac-platforms:migrationRationale": "both",
+  "cac-platforms:occursBetween": [
+    { "@id": "urn:uuid:e5f6a7b8-c9d0-1234-ef01-345678901234" },
+    { "@id": "urn:uuid:c3d4e5f6-a7b8-9012-cdef-123456789012" }
+  ]
+}

--- a/examples_knowledge_graphs/jsonld/coercion-cycle-example.jsonld
+++ b/examples_knowledge_graphs/jsonld/coercion-cycle-example.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "cac-sextortion": "https://cacontology.projectvic.org/sextortion#",
+    "cac-core": "https://cacontology.projectvic.org/core#",
+    "uco": "https://ontology.unifiedcyberontology.org/uco/core#",
+    "xsd": "http://www.w3.org/2001/XMLSchema#"
+  },
+  "@id": "urn:uuid:01234567-89ab-cdef-0123-456789abcdef",
+  "@type": "cac-sextortion:CoercionCycle",
+  "uco:description": "Self-sustaining loop: offender redeploys retained images to demand additional content.",
+  "cac-sextortion:sustainedBy": { "@id": "urn:uuid:f6a7b8c9-d0e1-2345-f012-456789012345" },
+  "cac-sextortion:cyclesBetween": [
+    { "@id": "urn:uuid:d4e5f6a7-b8c9-0123-def0-234567890123" },
+    { "@id": "urn:uuid:c3d4e5f6-a7b8-9012-cdef-123456789012" }
+  ],
+  "cac-sextortion:coercionCycleDemandType": "imagery_quota",
+  "cac-sextortion:terminationCondition": "apprehension"
+}

--- a/ontology/cacontology-core-shapes.ttl
+++ b/ontology/cacontology-core-shapes.ttl
@@ -509,3 +509,25 @@ cacontology:AgeAtTimeSituationShape rdf:type sh:NodeShape ;
             }
         """
     ] .
+
+# =============================================================================
+# PHASE SEQUENCING (cac-core:precedes)
+# =============================================================================
+
+cacontology:PhasePrecedesShape rdf:type sh:NodeShape ;
+    rdfs:label "Phase Precedes Shape"@en ;
+    rdfs:comment "Validates cac-core:precedes links between phase instances in offense trajectory graphs."@en ;
+    sh:targetClass cac-core:Phase ;
+    sh:property [
+        sh:path cac-core:precedes ;
+        sh:class cac-core:Phase ;
+        sh:minCount 0 ;
+        sh:message "Each cac-core:precedes object must be typed as a Phase instance (or subclass)."@en
+    ] .
+
+cacontology:PrecedesPropertyShape rdf:type sh:PropertyShape ;
+    rdfs:label "Precedes Property Shape"@en ;
+    rdfs:comment "Validates that the subject of cac-core:precedes is a Phase instance."@en ;
+    sh:path cac-core:precedes ;
+    sh:class cac-core:Phase ;
+    sh:message "The subject of cac-core:precedes must be typed as a Phase instance (or subclass)."@en .

--- a/ontology/cacontology-core-spine.ttl
+++ b/ontology/cacontology-core-spine.ttl
@@ -183,6 +183,13 @@ cac-core:isPhaseOf a owl:ObjectProperty ;
     rdfs:domain cac-core:Phase ;
     owl:inverseOf cac-core:hasPhase .
 
+cac-core:precedes a owl:ObjectProperty ;
+    rdfs:label "precedes"@en ;
+    rdfs:comment "Asserts that one exploitation phase or event directly precedes another in the documented offense timeline. Used to build temporally ordered traversal graphs for state machine analysis of case lifecycles. The subject phase occurs before the object phase in the same investigation."@en ;
+    rdfs:domain cac-core:Phase ;
+    rdfs:range cac-core:Phase ;
+    rdfs:isDefinedBy <https://cacontology.projectvic.org#> .
+
 cac-core:assesses a owl:ObjectProperty ;
     rdfs:label "assesses"@en ;
     rdfs:comment "Links an assessment result to the entity it evaluates."@en ;

--- a/ontology/cacontology-grooming-shapes.ttl
+++ b/ontology/cacontology-grooming-shapes.ttl
@@ -5,6 +5,7 @@
 @prefix gufo: <http://purl.org/nemo/gufo#> .
 @prefix uco-core: <https://ontology.unifiedcyberontology.org/uco/core/> .
 @prefix uco-identity: <https://ontology.unifiedcyberontology.org/uco/identity/> .
+@prefix uco-observable: <https://ontology.unifiedcyberontology.org/uco/observable/> .
 @prefix cacontology-grooming: <https://cacontology.projectvic.org/grooming#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix dcterms: <http://purl.org/dc/terms/> .
@@ -828,4 +829,42 @@ cacontology-grooming:GroomingDataQualityShape rdf:type sh:NodeShape ;
         sh:minInclusive 0.0 ;
         sh:maxInclusive 1.0 ;
         sh:maxCount 1 ;
-        sh:message "Analysis completeness must be between 0.0 and 1.0 (gUFO quality aspect)"@en     ] . 
+        sh:message "Analysis completeness must be between 0.0 and 1.0 (gUFO quality aspect)"@en     ] .
+
+# =============================================================================
+# ACCOUNT REPLACEMENT EVENT SHAPES (CaseLinker state machine)
+# =============================================================================
+
+cacontology-grooming:AccountReplacementEventShape rdf:type sh:NodeShape ;
+    sh:targetClass cacontology-grooming:AccountReplacementEvent ;
+    rdfs:label "Account Replacement Event Shape"@en ;
+    rdfs:comment "Validation shape for account replacement after ban or block."@en ;
+    sh:property [
+        sh:path cacontology-grooming:triggeredBy ;
+        sh:datatype xsd:string ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:in ( "victim_block" "platform_ban" "detection_risk" "voluntary" ) ;
+        sh:message "Account replacement trigger must be victim_block, platform_ban, detection_risk, or voluntary."@en
+    ] ;
+    sh:property [
+        sh:path cacontology-grooming:resumesAt ;
+        sh:class cacontology-grooming:GroomingPhase ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:message "Account replacement must specify the phase resumed via resumesAt."@en
+    ] ;
+    sh:property [
+        sh:path cacontology-grooming:originalAccountId ;
+        sh:class uco-observable:Account ;
+        sh:minCount 0 ;
+        sh:maxCount 1 ;
+        sh:message "Original account may be specified at most once."@en
+    ] ;
+    sh:property [
+        sh:path cacontology-grooming:replacementAccountId ;
+        sh:class uco-observable:Account ;
+        sh:minCount 0 ;
+        sh:maxCount 1 ;
+        sh:message "Replacement account may be specified at most once."@en
+    ] . 

--- a/ontology/cacontology-grooming.ttl
+++ b/ontology/cacontology-grooming.ttl
@@ -991,4 +991,37 @@ cacontology-grooming:transitionsToLocation rdf:type owl:ObjectProperty ;
     rdfs:label "transitions to location"@en ;
     rdfs:comment "Links public-to-private grooming to exploitation location."@en ;
     rdfs:domain cacontology-grooming:PublicToPrivateGrooming ;
-    rdfs:range uco-location:Location . 
+    rdfs:range uco-location:Location .
+
+# =============================================================================
+# ACCOUNT REPLACEMENT EVENT (ban evasion trajectory reset)
+# =============================================================================
+
+cacontology-grooming:AccountReplacementEvent rdf:type owl:Class ;
+    rdfs:label "Account Replacement Event"@en ;
+    rdfs:comment "Pattern where an offender whose account is banned or blocked creates a new account and returns to an earlier offense phase (typically initial contact). The lifecycle resets rather than terminates — structurally distinct from a coercion cycle."@en ;
+    rdfs:subClassOf cac-core:ExploitationEvent .
+
+cacontology-grooming:triggeredBy rdf:type owl:DatatypeProperty ;
+    rdfs:label "triggered by"@en ;
+    rdfs:comment "What triggered account replacement (victim_block, platform_ban, detection_risk, voluntary)."@en ;
+    rdfs:domain cacontology-grooming:AccountReplacementEvent ;
+    rdfs:range xsd:string .
+
+cacontology-grooming:resumesAt rdf:type owl:ObjectProperty ;
+    rdfs:label "resumes at"@en ;
+    rdfs:comment "Phase instance the offender returns to after account replacement (typically InitialContactPhase)."@en ;
+    rdfs:domain cacontology-grooming:AccountReplacementEvent ;
+    rdfs:range cacontology-grooming:GroomingPhase .
+
+cacontology-grooming:originalAccountId rdf:type owl:ObjectProperty ;
+    rdfs:label "original account id"@en ;
+    rdfs:comment "Reference to the banned or blocked account if known."@en ;
+    rdfs:domain cacontology-grooming:AccountReplacementEvent ;
+    rdfs:range uco-observable:Account .
+
+cacontology-grooming:replacementAccountId rdf:type owl:ObjectProperty ;
+    rdfs:label "replacement account id"@en ;
+    rdfs:comment "Reference to the new account used to resume contact if known."@en ;
+    rdfs:domain cacontology-grooming:AccountReplacementEvent ;
+    rdfs:range uco-observable:Account . 

--- a/ontology/cacontology-platforms-shapes.ttl
+++ b/ontology/cacontology-platforms-shapes.ttl
@@ -3,7 +3,9 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .
 @prefix uco-core: <https://ontology.unifiedcyberontology.org/uco/core/> .
+@prefix uco-observable: <https://ontology.unifiedcyberontology.org/uco/observable/> .
 @prefix cacontology-platforms: <https://cacontology.projectvic.org/platforms#> .
+@prefix cac-core: <https://cacontology.projectvic.org/core#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix dcterms: <http://purl.org/dc/terms/> .
 
@@ -773,4 +775,86 @@ cacontology-platforms:ModerationThroughputMetricsShape rdf:type sh:NodeShape ;
         sh:minCount 0 ;
         sh:maxCount 1 ;
         sh:message "Flag volume per month must be a non-negative integer when present."@en
+    ] .
+
+# =============================================================================
+# CHANNEL MIGRATION EVENT SHAPES (CaseLinker state machine)
+# =============================================================================
+
+cacontology-platforms:ChannelMigrationEventShape rdf:type sh:NodeShape ;
+    sh:targetClass cacontology-platforms:ChannelMigrationEvent ;
+    rdfs:label "Channel Migration Event Shape"@en ;
+    rdfs:comment "Validation shape for cross-platform channel migration events."@en ;
+    sh:property [
+        sh:path cacontology-platforms:fromPlatform ;
+        sh:class uco-observable:DigitalService ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:message "Channel migration must specify exactly one originating platform."@en
+    ] ;
+    sh:property [
+        sh:path cacontology-platforms:toPlatform ;
+        sh:class uco-observable:DigitalService ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:message "Channel migration must specify exactly one destination platform."@en
+    ] ;
+    sh:property [
+        sh:path cacontology-platforms:migrationRationale ;
+        sh:datatype xsd:string ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:in ( "capability_upgrade" "evidence_evasion" "both" ) ;
+        sh:message "Migration rationale must be capability_upgrade, evidence_evasion, or both."@en
+    ] ;
+    sh:property [
+        sh:path cacontology-platforms:occursBetween ;
+        sh:class cac-core:Phase ;
+        sh:minCount 2 ;
+        sh:message "Channel migration must separate at least two offense phases via occursBetween."@en
+    ] .
+
+# =============================================================================
+# AFFORDANCE MISUSE SHAPES (CaseLinker state machine)
+# =============================================================================
+
+cacontology-platforms:AffordanceMisuseShape rdf:type sh:NodeShape ;
+    sh:targetClass cacontology-platforms:AffordanceMisuse ;
+    rdfs:label "Affordance Misuse Shape"@en ;
+    rdfs:comment "Validation shape for transition-level platform affordance misuse annotations."@en ;
+    sh:property [
+        sh:path cacontology-platforms:affordanceClass ;
+        sh:class cacontology-platforms:PlatformAffordance ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:message "Affordance misuse must specify exactly one affordance class."@en
+    ] ;
+    sh:property [
+        sh:path cacontology-platforms:enablesTransitionFrom ;
+        sh:class cac-core:Phase ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:message "Affordance misuse must specify the source phase via enablesTransitionFrom."@en
+    ] ;
+    sh:property [
+        sh:path cacontology-platforms:enablesTransitionTo ;
+        sh:class cac-core:Phase ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:message "Affordance misuse must specify the target phase via enablesTransitionTo."@en
+    ] ;
+    sh:property [
+        sh:path cacontology-platforms:misuseDescription ;
+        sh:datatype xsd:string ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:minLength 10 ;
+        sh:message "Affordance misuse must include a misuse description of at least 10 characters."@en
+    ] ;
+    sh:property [
+        sh:path cacontology-platforms:platform ;
+        sh:class uco-observable:DigitalService ;
+        sh:minCount 0 ;
+        sh:maxCount 1 ;
+        sh:message "Optional platform instance may be specified at most once."@en
     ] .

--- a/ontology/cacontology-platforms.ttl
+++ b/ontology/cacontology-platforms.ttl
@@ -8,6 +8,7 @@
 @prefix uco-observable: <https://ontology.unifiedcyberontology.org/uco/observable/> .
 @prefix uco-action: <https://ontology.unifiedcyberontology.org/uco/action/> .
 @prefix cacontology-platforms: <https://cacontology.projectvic.org/platforms#> .
+@prefix cacontology-grooming: <https://cacontology.projectvic.org/grooming#> .
 @prefix gufo: <http://purl.org/nemo/gufo#> .
 @prefix cac-core: <https://cacontology.projectvic.org/core#> .
 
@@ -25,6 +26,8 @@
                 <https://ontology.unifiedcyberontology.org/uco/identity/> ,
                 <https://ontology.unifiedcyberontology.org/uco/action/> ,
                 <https://cacontology.projectvic.org/3.0.0> ,
+                <https://cacontology.projectvic.org/core/3.0.0> ,
+                <https://cacontology.projectvic.org/grooming/3.0.0> ,
                 <http://purl.org/nemo/gufo#> .
 
 # =============================================================================
@@ -939,4 +942,125 @@ cacontology-platforms:providesOpenChatAccess rdf:type owl:ObjectProperty ;
     rdfs:label "provides open chat access"@en ;
     rdfs:comment "Links contact opportunity to open chat room access."@en ;
     rdfs:domain cacontology-platforms:AnonymousContactOpportunity ;
-    rdfs:range cacontology-platforms:OpenChatRooms . 
+    rdfs:range cacontology-platforms:OpenChatRooms .
+
+# =============================================================================
+# PLATFORM AFFORDANCES (capability taxonomy for transition-level misuse)
+# =============================================================================
+
+cacontology-platforms:PlatformAffordance rdf:type owl:Class ;
+    rdfs:label "Platform Affordance"@en ;
+    rdfs:comment "A platform capability that offenders may misuse to advance an offense trajectory (anonymity, ephemerality, unmonitored communication, etc.)."@en ;
+    rdfs:subClassOf uco-core:UcoObject, cac-core:DigitalSystemEntity .
+
+cacontology-platforms:Anonymity rdf:type owl:Class ;
+    rdfs:label "Anonymity Affordance"@en ;
+    rdfs:comment "Platform affordance enabling pseudonymous or minimally verified contact."@en ;
+    rdfs:subClassOf cacontology-platforms:PlatformAffordance .
+
+cacontology-platforms:Ephemerality rdf:type owl:Class ;
+    rdfs:label "Ephemerality Affordance"@en ;
+    rdfs:comment "Platform affordance where messages or media auto-delete, reducing forensic retention on the platform."@en ;
+    rdfs:subClassOf cacontology-platforms:PlatformAffordance .
+
+cacontology-platforms:UnmonitoredCommunication rdf:type owl:Class ;
+    rdfs:label "Unmonitored Communication Affordance"@en ;
+    rdfs:comment "Platform affordance for private channels with limited proactive moderation or parental visibility."@en ;
+    rdfs:subClassOf cacontology-platforms:PlatformAffordance .
+
+cacontology-platforms:ContactDiscovery rdf:type owl:Class ;
+    rdfs:label "Contact Discovery Affordance"@en ;
+    rdfs:comment "Platform affordance for finding or matching with new contacts (search, suggestions, random matching)."@en ;
+    rdfs:subClassOf cacontology-platforms:PlatformAffordance .
+
+cacontology-platforms:DistributionInfrastructure rdf:type owl:Class ;
+    rdfs:label "Distribution Infrastructure Affordance"@en ;
+    rdfs:comment "Platform affordance for sharing or broadcasting content to audiences beyond direct dyadic chat."@en ;
+    rdfs:subClassOf cacontology-platforms:PlatformAffordance .
+
+cacontology-platforms:GenerativeSynthesis rdf:type owl:Class ;
+    rdfs:label "Generative Synthesis Affordance"@en ;
+    rdfs:comment "Platform affordance for AI-generated or synthetic media creation and manipulation."@en ;
+    rdfs:subClassOf cacontology-platforms:PlatformAffordance .
+
+cacontology-platforms:Coordination rdf:type owl:Class ;
+    rdfs:label "Coordination Affordance"@en ;
+    rdfs:comment "Platform affordance for group coordination, encrypted channels, or multi-party planning."@en ;
+    rdfs:subClassOf cacontology-platforms:PlatformAffordance .
+
+cacontology-platforms:CoercionLeverage rdf:type owl:Class ;
+    rdfs:label "Coercion Leverage Affordance"@en ;
+    rdfs:comment "Platform affordance that amplifies coercive leverage (screenshots, forwarding, contact export, payment rails)."@en ;
+    rdfs:subClassOf cacontology-platforms:PlatformAffordance .
+
+# =============================================================================
+# CHANNEL MIGRATION EVENT (cross-platform offense trajectory transition)
+# =============================================================================
+
+cacontology-platforms:ChannelMigrationEvent rdf:type owl:Class ;
+    rdfs:label "Channel Migration Event"@en ;
+    rdfs:comment "Documented offense pattern where contact is initiated on one platform and deliberately moved to a second platform before escalation, to access more capable channels and/or sever the evidence trail on the originating platform."@en ;
+    rdfs:subClassOf cac-core:ExploitationEvent .
+
+cacontology-platforms:fromPlatform rdf:type owl:ObjectProperty ;
+    rdfs:label "from platform"@en ;
+    rdfs:comment "Originating platform from which the offender migrated contact."@en ;
+    rdfs:domain cacontology-platforms:ChannelMigrationEvent ;
+    rdfs:range uco-observable:DigitalService .
+
+cacontology-platforms:toPlatform rdf:type owl:ObjectProperty ;
+    rdfs:label "to platform"@en ;
+    rdfs:comment "Destination platform to which contact was migrated."@en ;
+    rdfs:domain cacontology-platforms:ChannelMigrationEvent ;
+    rdfs:range uco-observable:DigitalService .
+
+cacontology-platforms:migrationRationale rdf:type owl:DatatypeProperty ;
+    rdfs:label "migration rationale"@en ;
+    rdfs:comment "Why the offender migrated channels (capability_upgrade, evidence_evasion, both)."@en ;
+    rdfs:domain cacontology-platforms:ChannelMigrationEvent ;
+    rdfs:range xsd:string .
+
+cacontology-platforms:occursBetween rdf:type owl:ObjectProperty ;
+    rdfs:label "occurs between"@en ;
+    rdfs:comment "Offense phase instances separated by this channel migration event (earlier phase, later phase)."@en ;
+    rdfs:domain cacontology-platforms:ChannelMigrationEvent ;
+    rdfs:range cac-core:Phase .
+
+# =============================================================================
+# AFFORDANCE MISUSE (transition-level affordance annotation)
+# =============================================================================
+
+cacontology-platforms:AffordanceMisuse rdf:type owl:Class ;
+    rdfs:label "Affordance Misuse"@en ;
+    rdfs:comment "Annotation linking a platform affordance to the phase transition it enabled — affordances on offense trajectory edges rather than platform nodes alone."@en ;
+    rdfs:subClassOf uco-core:Relationship .
+
+cacontology-platforms:affordanceClass rdf:type owl:ObjectProperty ;
+    rdfs:label "affordance class"@en ;
+    rdfs:comment "The platform affordance category misused to enable the transition."@en ;
+    rdfs:domain cacontology-platforms:AffordanceMisuse ;
+    rdfs:range cacontology-platforms:PlatformAffordance .
+
+cacontology-platforms:enablesTransitionFrom rdf:type owl:ObjectProperty ;
+    rdfs:label "enables transition from"@en ;
+    rdfs:comment "Phase instance from which the affordance-enabled transition originates."@en ;
+    rdfs:domain cacontology-platforms:AffordanceMisuse ;
+    rdfs:range cac-core:Phase .
+
+cacontology-platforms:enablesTransitionTo rdf:type owl:ObjectProperty ;
+    rdfs:label "enables transition to"@en ;
+    rdfs:comment "Phase instance to which the affordance-enabled transition leads."@en ;
+    rdfs:domain cacontology-platforms:AffordanceMisuse ;
+    rdfs:range cac-core:Phase .
+
+cacontology-platforms:platform rdf:type owl:ObjectProperty ;
+    rdfs:label "platform"@en ;
+    rdfs:comment "Optional platform instance that carried the misused affordance."@en ;
+    rdfs:domain cacontology-platforms:AffordanceMisuse ;
+    rdfs:range uco-observable:DigitalService .
+
+cacontology-platforms:misuseDescription rdf:type owl:DatatypeProperty ;
+    rdfs:label "misuse description"@en ;
+    rdfs:comment "Narrative description of how the affordance was misused to enable the phase transition."@en ;
+    rdfs:domain cacontology-platforms:AffordanceMisuse ;
+    rdfs:range xsd:string . 

--- a/ontology/cacontology-sextortion-shapes.ttl
+++ b/ontology/cacontology-sextortion-shapes.ttl
@@ -5,6 +5,7 @@
 @prefix uco-core: <https://ontology.unifiedcyberontology.org/uco/core/> .
 @prefix uco-identity: <https://ontology.unifiedcyberontology.org/uco/identity/> .
 @prefix cacontology-sextortion: <https://cacontology.projectvic.org/sextortion#> .
+@prefix cac-core: <https://cacontology.projectvic.org/core#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix dcterms: <http://purl.org/dc/terms/> .
 
@@ -675,4 +676,41 @@ cacontology-sextortion:DataQualityShape rdf:type sh:NodeShape ;
         sh:minLength 10 ;
         sh:maxLength 1000 ;
         sh:message "Comment should be between 10 and 1000 characters when provided."@en
+    ] .
+
+# =============================================================================
+# COERCION CYCLE SHAPES (CaseLinker state machine)
+# =============================================================================
+
+cacontology-sextortion:CoercionCycleShape rdf:type sh:NodeShape ;
+    sh:targetClass cacontology-sextortion:CoercionCycle ;
+    rdfs:label "Coercion Cycle Shape"@en ;
+    rdfs:comment "Validation shape for sextortion coercion cycle instances."@en ;
+    sh:property [
+        sh:path cacontology-sextortion:sustainedBy ;
+        sh:class cac-core:Artifact ;
+        sh:minCount 1 ;
+        sh:message "Coercion cycle must reference retained leverage material via sustainedBy."@en
+    ] ;
+    sh:property [
+        sh:path cacontology-sextortion:cyclesBetween ;
+        sh:class cac-core:Phase ;
+        sh:minCount 2 ;
+        sh:message "Coercion cycle must link at least two phase instances via cyclesBetween."@en
+    ] ;
+    sh:property [
+        sh:path cacontology-sextortion:coercionCycleDemandType ;
+        sh:datatype xsd:string ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:in ( "imagery_quota" "live_conduct" "financial" "victim_recruitment" ) ;
+        sh:message "Coercion cycle demand type must be imagery_quota, live_conduct, financial, or victim_recruitment."@en
+    ] ;
+    sh:property [
+        sh:path cacontology-sextortion:terminationCondition ;
+        sh:datatype xsd:string ;
+        sh:minCount 0 ;
+        sh:maxCount 1 ;
+        sh:in ( "apprehension" "material_removal" "victim_ceased_response" "unknown" ) ;
+        sh:message "Termination condition must be apprehension, material_removal, victim_ceased_response, or unknown."@en
     ] . 

--- a/ontology/cacontology-sextortion.ttl
+++ b/ontology/cacontology-sextortion.ttl
@@ -579,4 +579,37 @@ cacontology-sextortion:providesEvidence rdf:type owl:ObjectProperty ;
     rdfs:label "provides evidence"@en ;
     rdfs:comment "Links sextortion investigation to evidence provided for prosecution."@en ;
     rdfs:domain cacontology-sextortion:SextortionInvestigation ;
-    rdfs:range uco-observable:ObservableObject . 
+    rdfs:range uco-observable:ObservableObject .
+
+# =============================================================================
+# COERCION CYCLE (sextortion self-sustaining leverage loop)
+# =============================================================================
+
+cacontology-sextortion:CoercionCycle rdf:type owl:Class ;
+    rdfs:label "Coercion Cycle"@en ;
+    rdfs:comment "Self-sustaining sextortion loop in which retained imagery becomes perpetual leverage: the offender redeploys the same retained material to demand new content, extending leverage further without acquiring new initial leverage. Structurally distinct from a single threat-delivery event; the cycle has no natural termination except apprehension or removal of material."@en ;
+    rdfs:subClassOf cac-core:Situation, cac-core:ExploitationEvent .
+
+cacontology-sextortion:sustainedBy rdf:type owl:ObjectProperty ;
+    rdfs:label "sustained by"@en ;
+    rdfs:comment "Retained material or artifact that powers the coercion cycle (e.g., intimate images retained from prior exploitation)."@en ;
+    rdfs:domain cacontology-sextortion:CoercionCycle ;
+    rdfs:range cac-core:Artifact .
+
+cacontology-sextortion:cyclesBetween rdf:type owl:ObjectProperty ;
+    rdfs:label "cycles between"@en ;
+    rdfs:comment "Phase instances that form the coercion loop (typically threat delivery and exploitation phases in sextortion, or equivalent phase nodes in other offense trajectories)."@en ;
+    rdfs:domain cacontology-sextortion:CoercionCycle ;
+    rdfs:range cac-core:Phase .
+
+cacontology-sextortion:terminationCondition rdf:type owl:DatatypeProperty ;
+    rdfs:label "termination condition"@en ;
+    rdfs:comment "How the coercion cycle ended if known (apprehension, material_removal, victim_ceased_response, unknown)."@en ;
+    rdfs:domain cacontology-sextortion:CoercionCycle ;
+    rdfs:range xsd:string .
+
+cacontology-sextortion:coercionCycleDemandType rdf:type owl:DatatypeProperty ;
+    rdfs:label "coercion cycle demand type"@en ;
+    rdfs:comment "Type of demand driving a coercion cycle iteration (imagery_quota, live_conduct, financial, victim_recruitment)."@en ;
+    rdfs:domain cacontology-sextortion:CoercionCycle ;
+    rdfs:range xsd:string . 

--- a/testing/shacl_validation.py
+++ b/testing/shacl_validation.py
@@ -184,6 +184,9 @@ domain_validations = [
     ('examples_knowledge_graphs/miami-icac-felipe-lopez-example.ttl', 'ontology/cacontology-legal-outcomes-shapes.ttl'),
     ('examples_knowledge_graphs/k2p-soe-information-example.ttl', 'ontology/cacontology-sadistic-online-exploitation-shapes.ttl'),
     ('examples_knowledge_graphs/k2p-soe-information-example.ttl', 'ontology/cacontology-sextortion-shapes.ttl'),
+    ('examples_knowledge_graphs/caselinker-state-machine-extensions-example.ttl', 'ontology/cacontology-sextortion-shapes.ttl'),
+    ('examples_knowledge_graphs/caselinker-state-machine-extensions-example.ttl', 'ontology/cacontology-platforms-shapes.ttl'),
+    ('examples_knowledge_graphs/caselinker-account-replacement-example.ttl', 'ontology/cacontology-grooming-shapes.ttl'),
 ]
 
 domain_passed = 0

--- a/testing/state-machine-extensions-prep.md
+++ b/testing/state-machine-extensions-prep.md
@@ -1,0 +1,111 @@
+# Contribution prep — CaseLinker state machine extensions
+
+Local checklist only. Complete before opening a PR to Project VIC. **No git actions required to use this file.**
+
+## What you are contributing
+
+| Module | New terms |
+|--------|-----------|
+| `cacontology-sextortion` | `CoercionCycle` + 4 properties |
+| `cacontology-platforms` | `PlatformAffordance` (+ 8 subclasses), `ChannelMigrationEvent`, `AffordanceMisuse` |
+| `cacontology-grooming` | `AccountReplacementEvent` + 4 properties |
+
+Supporting: SHACL shapes, example TTL/JSON-LD, SPARQL query, optional Python SDK, unit tests.
+
+## Documentation hygiene (done in this branch)
+
+- [x] `CHANGELOG.md` — `[Unreleased]` entry
+- [x] `docs/glossary.md` — new classes and key properties
+- [x] `docs/user_doc.md` — usage section with IRIs and validation commands
+- [x] `contexts/cacontology-{sextortion,platforms,grooming,state-machine-extensions}.jsonld`
+- [x] `example_SPARQL_queries/caselinker-state-machine-analytics.rq`
+- [x] `testing/shacl_validation.py` — domain cross-checks for example graph
+
+## Validation checklist (run locally)
+
+```bash
+cd /path/to/CAC-Ontology
+python3 -m venv .venv && source .venv/bin/activate
+pip install rdflib pyshacl
+
+# 1. Full SHACL suite (must be 0 failures)
+python testing/shacl_validation.py
+
+# 2. State-machine unit tests (8 tests)
+python testing/test_state_machine_extensions.py -v
+
+# 3. Per-module example validation
+python -m pyshacl -s ontology/cacontology-sextortion-shapes.ttl \
+  -d examples_knowledge_graphs/caselinker-state-machine-extensions-example.ttl
+python -m pyshacl -s ontology/cacontology-platforms-shapes.ttl \
+  -d examples_knowledge_graphs/caselinker-state-machine-extensions-example.ttl
+python -m pyshacl -s ontology/cacontology-grooming-shapes.ttl \
+  -d examples_knowledge_graphs/caselinker-account-replacement-example.ttl
+
+# 4. Optional: ROBOT syntax check (if installed)
+# robot validate --input ontology/cacontology-sextortion.ttl
+# robot validate --input ontology/cacontology-platforms.ttl
+# robot validate --input ontology/cacontology-grooming.ttl
+
+# 5. Optional: Docker validation (CONTRIBUTING.md)
+# cd testing && docker compose up -d && docker compose run pyshacl
+```
+
+Record results here before PR:
+
+| Check | Pass? | Notes |
+|-------|-------|-------|
+| `shacl_validation.py` | Yes | 158 pass / 0 fail |
+| `test_state_machine_extensions.py` | Yes | 8/8 |
+| Example vs sextortion shapes | Yes | `caselinker-state-machine-extensions-example.ttl` |
+| Example vs platforms shapes | Yes | same file |
+| Example vs grooming shapes | Yes | `caselinker-account-replacement-example.ttl` (separate file avoids cross-module Phase shape conflicts) |
+| `cac-core:precedes` SHACL | Yes | Defined in `cacontology-core-spine.ttl`; shapes in `cacontology-core-shapes.ttl` |
+| Module JSON-LD contexts | Yes | `contexts/cacontology-{sextortion,platforms,grooming}.jsonld` |
+| ROBOT (optional) | | See below |
+
+## Before you commit (your steps — not done by agent)
+
+1. `git checkout -b feat/caselinker-state-machine-extensions`
+2. `git add` only contribution files (review `git status` — exclude `.cursor/`, local secrets)
+3. Commit with conventional message, e.g.:
+
+```
+feat: add CaseLinker state machine offense trajectory classes
+
+- Add CoercionCycle, ChannelMigrationEvent, AffordanceMisuse, AccountReplacementEvent
+- SHACL shapes, example KG, JSON-LD context, SPARQL analytics query
+- Optional Python SDK bindings and unit tests
+```
+
+4. Add DCO sign-off line to commit body:
+
+```
+Signed-off-by: Your Name <your.email@example.com>
+```
+
+## PR description draft (fill in when ready)
+
+**Title:** `feat: add CaseLinker state machine offense trajectory classes`
+
+**Summary:**
+- Closes gap for cyclic sextortion leverage (`CoercionCycle`)
+- Cross-platform migration as typed event (`ChannelMigrationEvent`)
+- Transition-level platform affordance annotation (`AffordanceMisuse`)
+- Post-ban account reset (`AccountReplacementEvent`)
+
+**Motivation:** CaseLinker maps ICAC case features to a formal exploitation state machine; these four constructs were missing from CAC.
+
+**Validation:** pyshacl 158/158 pass; unit tests 8/8. ROBOT validation not run (not installed locally).
+
+**Note for reviewers:** `coercionCycleDemandType` is intentionally separate from `ExtortionDemand.demandType`. `cac-core:precedes` already existed in the semantic spine; this PR clarifies it and adds SHACL only. `sdk/python/` is optional — happy to drop or relocate per project preference.
+
+## Files touched (review `git diff`)
+
+**Ontology:** `ontology/cacontology-sextortion.ttl`, `ontology/cacontology-platforms.ttl`, `ontology/cacontology-grooming.ttl`, `ontology/cacontology-core-spine.ttl`, matching `*-shapes.ttl` (including `cacontology-core-shapes.ttl`)
+
+**Examples:** `examples_knowledge_graphs/caselinker-state-machine-extensions-example.ttl`, `examples_knowledge_graphs/caselinker-account-replacement-example.ttl`, `examples_knowledge_graphs/jsonld/*.jsonld`
+
+**Docs:** `CHANGELOG.md`, `docs/glossary.md`, `docs/user_doc.md`
+
+**Other:** `contexts/`, `example_SPARQL_queries/`, `sdk/python/`, `testing/test_state_machine_extensions.py`, `testing/shacl_validation.py`

--- a/testing/state-machine-extensions-prep.md
+++ b/testing/state-machine-extensions-prep.md
@@ -60,7 +60,7 @@ Record results here before PR:
 | Example vs sextortion shapes | Yes | `caselinker-state-machine-extensions-example.ttl` |
 | Example vs platforms shapes | Yes | same file |
 | Example vs grooming shapes | Yes | `caselinker-account-replacement-example.ttl` (separate file avoids cross-module Phase shape conflicts) |
-| `cac-core:precedes` SHACL | Yes | Defined in `cacontology-core-spine.ttl`; shapes in `cacontology-core-shapes.ttl` |
+| `cac-core:precedes` SHACL | Yes | **New property** in `cacontology-core-spine.ttl` (not on main before this branch); shapes in `cacontology-core-shapes.ttl` |
 | Module JSON-LD contexts | Yes | `contexts/cacontology-{sextortion,platforms,grooming}.jsonld` |
 | ROBOT (optional) | | See below |
 
@@ -98,7 +98,7 @@ Signed-off-by: Your Name <your.email@example.com>
 
 **Validation:** pyshacl 158/158 pass; unit tests 8/8. ROBOT validation not run (not installed locally).
 
-**Note for reviewers:** `coercionCycleDemandType` is intentionally separate from `ExtortionDemand.demandType`. `cac-core:precedes` already existed in the semantic spine; this PR clarifies it and adds SHACL only. `sdk/python/` is optional — happy to drop or relocate per project preference.
+**Note for reviewers:** `coercionCycleDemandType` is intentionally separate from `ExtortionDemand.demandType`. `cac-core:precedes` is a **new** spine property introduced in this PR (git blame: commit `1a9deca`); prior ordering used module-local properties (`transitionsTo`, `temporallyPrecedes`, `precedesPhase`). UCO/CASE define no equivalent. `sdk/python/` is optional — happy to drop or relocate per project preference.
 
 ## Files touched (review `git diff`)
 

--- a/testing/test_state_machine_extensions.py
+++ b/testing/test_state_machine_extensions.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""Unit tests for CaseLinker state machine extension classes."""
+
+import os
+import sys
+import unittest
+
+os.chdir(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, os.path.join(os.getcwd(), "sdk", "python"))
+
+from pyshacl import validate
+import rdflib
+
+from cacontology import (
+    AccountReplacementEvent,
+    AffordanceMisuse,
+    ChannelMigrationEvent,
+    CoercionCycle,
+)
+
+REPO = os.getcwd()
+
+
+def shacl_validate(data_graph: rdflib.Graph, shapes_path: str) -> bool:
+    shapes_graph = rdflib.Graph()
+    shapes_graph.parse(shapes_path, format="turtle")
+    conforms, _, _ = validate(
+        data_graph,
+        shacl_graph=shapes_graph,
+        inference="none",
+        abort_on_first=False,
+        allow_infos=True,
+        allow_warnings=True,
+    )
+    return conforms
+
+
+class TestCoercionCycle(unittest.TestCase):
+  shapes = os.path.join(REPO, "ontology", "cacontology-sextortion-shapes.ttl")
+
+  def test_valid_instance_passes_shacl(self):
+    cycle = CoercionCycle(
+      id="urn:uuid:test-coercion-cycle-valid",
+      sustained_by="urn:uuid:test-artifact-001",
+      cycles_between=[
+        "urn:uuid:test-extortion-phase",
+        "urn:uuid:test-image-phase",
+      ],
+      coercion_cycle_demand_type="imagery_quota",
+      termination_condition="unknown",
+    )
+    self.assertTrue(shacl_validate(cycle.to_graph(), self.shapes))
+    self.assertIn("@type", cycle.to_jsonld())
+    self.assertEqual(cycle.to_jsonld()["@type"], "cac-sextortion:CoercionCycle")
+
+  def test_missing_sustained_by_fails_shacl(self):
+    g = rdflib.Graph()
+    g.parse(
+      data="""
+      @prefix cac-sextortion: <https://cacontology.projectvic.org/sextortion#> .
+      <urn:uuid:test-coercion-cycle-invalid> a cac-sextortion:CoercionCycle ;
+        cac-sextortion:coercionCycleDemandType "imagery_quota" ;
+        cac-sextortion:cyclesBetween <urn:uuid:phase-a>, <urn:uuid:phase-b> .
+      """,
+      format="turtle",
+    )
+    self.assertFalse(shacl_validate(g, self.shapes))
+
+
+class TestChannelMigrationEvent(unittest.TestCase):
+  shapes = os.path.join(REPO, "ontology", "cacontology-platforms-shapes.ttl")
+
+  def test_valid_instance_passes_shacl(self):
+    event = ChannelMigrationEvent(
+      id="urn:uuid:test-channel-migration-valid",
+      from_platform="urn:uuid:platform-instagram",
+      to_platform="urn:uuid:platform-messenger",
+      migration_rationale="capability_upgrade",
+      occurs_between=["urn:uuid:phase-trust", "urn:uuid:phase-image"],
+    )
+    self.assertTrue(shacl_validate(event.to_graph(), self.shapes))
+    self.assertEqual(
+      event.to_jsonld()["cac-platforms:migrationRationale"], "capability_upgrade"
+    )
+
+  def test_invalid_rationale_fails_shacl(self):
+    g = rdflib.Graph()
+    g.parse(
+      data="""
+      @prefix cac-platforms: <https://cacontology.projectvic.org/platforms#> .
+      <urn:uuid:test-channel-migration-invalid> a cac-platforms:ChannelMigrationEvent ;
+        cac-platforms:fromPlatform <urn:uuid:platform-a> ;
+        cac-platforms:toPlatform <urn:uuid:platform-b> ;
+        cac-platforms:migrationRationale "invalid_value" ;
+        cac-platforms:occursBetween <urn:uuid:phase-a>, <urn:uuid:phase-b> .
+      """,
+      format="turtle",
+    )
+    self.assertFalse(shacl_validate(g, self.shapes))
+
+
+class TestAffordanceMisuse(unittest.TestCase):
+  shapes = os.path.join(REPO, "ontology", "cacontology-platforms-shapes.ttl")
+
+  def test_valid_instance_passes_shacl(self):
+    misuse = AffordanceMisuse(
+      id="urn:uuid:test-affordance-misuse-valid",
+      affordance_class="urn:uuid:affordance-ephemerality",
+      enables_transition_from="urn:uuid:phase-trust",
+      enables_transition_to="urn:uuid:phase-image",
+      misuse_description="Disappearing messages normalized image sharing before extortion.",
+      platform="urn:uuid:platform-snapchat",
+    )
+    self.assertTrue(shacl_validate(misuse.to_graph(), self.shapes))
+    self.assertIn("cac-platforms:misuseDescription", misuse.to_jsonld())
+
+  def test_missing_description_fails_shacl(self):
+    g = rdflib.Graph()
+    g.parse(
+      data="""
+      @prefix cac-platforms: <https://cacontology.projectvic.org/platforms#> .
+      <urn:uuid:test-affordance-misuse-invalid> a cac-platforms:AffordanceMisuse ;
+        cac-platforms:affordanceClass <urn:uuid:affordance-anonymity> ;
+        cac-platforms:enablesTransitionFrom <urn:uuid:phase-a> ;
+        cac-platforms:enablesTransitionTo <urn:uuid:phase-b> .
+      """,
+      format="turtle",
+    )
+    self.assertFalse(shacl_validate(g, self.shapes))
+
+
+class TestAccountReplacementEvent(unittest.TestCase):
+  shapes = os.path.join(REPO, "ontology", "cacontology-grooming-shapes.ttl")
+
+  def test_valid_instance_passes_shacl(self):
+    event = AccountReplacementEvent(
+      id="urn:uuid:test-account-replacement-valid",
+      triggered_by="platform_ban",
+      resumes_at="urn:uuid:phase-initial-contact",
+      original_account_id="urn:uuid:account-banned",
+      replacement_account_id="urn:uuid:account-new",
+    )
+    self.assertTrue(shacl_validate(event.to_graph(), self.shapes))
+    self.assertEqual(event.to_jsonld()["cac-grooming:triggeredBy"], "platform_ban")
+
+  def test_invalid_trigger_fails_shacl(self):
+    g = rdflib.Graph()
+    g.parse(
+      data="""
+      @prefix cac-grooming: <https://cacontology.projectvic.org/grooming#> .
+      <urn:uuid:test-account-replacement-invalid> a cac-grooming:AccountReplacementEvent ;
+        cac-grooming:triggeredBy "account_hack" ;
+        cac-grooming:resumesAt <urn:uuid:phase-initial-contact> .
+      """,
+      format="turtle",
+    )
+    self.assertFalse(shacl_validate(g, self.shapes))
+
+
+if __name__ == "__main__":
+  unittest.main()


### PR DESCRIPTION
## Summary

Adds four new ontology classes and supporting infrastructure to enable 
formal state machine modeling of ICAC exploitation lifecycles, developed 
through CaseLinker analysis of five PACER federal cases.

## Gaps filled

| Class | Module | Gap |
|---|---|---|
| `CoercionCycle` | sextortion | Self-sustaining leverage loop — distinct from linear `progressionStage` and single `ExtortionDemand` |
| `ChannelMigrationEvent` | platforms | Per-case typed migration event — distinct from enterprise-level `PlatformMigrationStrategy` |
| `AffordanceMisuse` | platforms | Affordance annotation on phase transitions, not platform nodes |
| `AccountReplacementEvent` | grooming | Post-ban lifecycle reset with `resumesAt` phase pointer — distinct from `AlternateAccountSystem` |

## Validation

- pyshacl: 158/158 pass
- Unit tests: 8/8 pass
- ROBOT: not run locally — happy to run in CI

## Files changed

- 4 ontology TTL modules modified (sextortion, platforms, grooming, core-spine)
- 4 SHACL shapes files updated
- 2 example TTL files added
- 4 JSON-LD example files added
- 4 JSON-LD context files added (3 module + 1 combined)
- 1 SPARQL analytics query added
- CHANGELOG.md, docs/glossary.md, docs/user_doc.md updated

## Note on cac-core:precedes
cac-core:precedes is a new spine property introduced in this PR — 
it did not exist on main (a923beb) prior to this branch. The full 
property definition (declaration, domain, range, label, comment, 
rdfs:isDefinedBy) was added in this commit. It is required for 
formal phase ordering in state machine traversal across all four 
contributions. CASE and UCO have no equivalent property. 
Flagged explicitly as a core spine addition for maintainer review.

## Context

Developed in coordination with Cory Hall (Project VIC International) as part of CaseLinker exploitation state machine modeling. Serves as representation for state machines and basis for Exploitation theorems in upcoming Affordances for Harm paper.  Discussed via email June 22, 2026.