### PR TITLE
feat(examples): add NCMEC CyberTipline 2025 aggregate statistics KG

### DIFF
--- a/analytics_demonstration/collected_sources/ncmec-cybertipline-data/duplicate_detection_report.md
+++ b/analytics_demonstration/collected_sources/ncmec-cybertipline-data/duplicate_detection_report.md
@@ -1,0 +1,38 @@
+# Duplicate Detection Report (Local Repo Scan)
+
+- **Source URL**: `https://www.missingkids.org/cybertiplinedata`
+- **caseId**: `ncmec-cybertipline-data`
+- **Scan date (UTC)**: 2026-07-19T05:03:58Z
+- **Method**: local repo scan of `analytics_demonstration/collected_sources/` and `examples_knowledge_graphs/` for exact URL match (in lieu of a triplestore SPARQL duplicate check). Near-duplicate title/keyword scan for CyberTipline / NCMEC aggregate data pages.
+
+## Findings
+
+| Check | Result |
+|---|---|
+| Exact URL in `collected_sources/*/manifest.yaml` | **none** |
+| Exact URL in `collected_sources/*/source.txt` | **none** |
+| Exact URL in `examples_knowledge_graphs/*.ttl` | **none** |
+| caseId directory already present | **none** prior to this collection |
+| Near-duplicate title "CyberTipline Data" / "2025 CyberTipline Report" as primary source | **none** |
+
+### Related (non-duplicate) mentions
+
+Repo contains other graphs that **reference** NCMEC/CyberTip concepts (e.g. investigation lifecycle examples, Utah cases, partnerships). Those are different sources/cases and do not constitute a prior collection of this public statistics page.
+
+## Entity resolution (near-duplicate)
+
+- **Status**: not executed beyond keyword/URL scan
+- **Reason**: single-document Path A; no vector index / Graph DB ER stack configured for volunteer workflow
+
+## Decision
+
+- **Action**: **PROCEED** with collection
+- **Reason**: No exact or near-duplicate primary source collection detected for this URL/page
+
+## Content hashes (for future deduplication)
+
+| Artifact | Size (bytes) | SHA-256 |
+|---|---:|---|
+| `source.html` (raw) | 725977 | `db3cf9214fb28679b5f709ec54a36aff3aa0fa0bd431ae6fff3bb52d75e9e9c4` |
+| `source.txt` (clean prose) | 22420 | `4b4e83f0c20e47b3289292441149cf98bbc4d6af622712015a09a2c73b8c95e6` |
+| `normalized.txt` (keypoints) | 8746 | `f0d8b0431066a09a0b5b444f618bf874083ad088c861ade132b23ea891a9a617` |

--- a/analytics_demonstration/collected_sources/ncmec-cybertipline-data/manifest.yaml
+++ b/analytics_demonstration/collected_sources/ncmec-cybertipline-data/manifest.yaml
@@ -1,0 +1,148 @@
+# CAC Ontology ingestion manifest (single-document) — C2.A1 Phase -1 + Phase 0
+# Source: NCMEC 2025 CyberTipline public aggregate statistics page
+# Path A caseId: ncmec-cybertipline-data
+
+batch:
+  uco-core:id: "urn:uuid:6e03e099-e6fe-5486-bab5-e498c172459a"
+  uco-core:name: "NCMEC 2025 CyberTipline Data page collection"
+  uco-core:objectCreatedTime: "2026-07-19T05:03:58Z"
+
+  agentOrchestration:
+    enabled: false
+    fetchMethod: "manual"
+    preprocessingPipeline:
+      - "http_get_html"
+      - "manual_substantive_extract"
+      - "whitespace_normalize"
+      - "strip_nav_chrome"
+      - "strip_script_noise"
+      - "strip_donation_chrome"
+      - "omit_archive_pdf_link_lists"
+      - "keypoint_normalize"
+    deconflictionEnabled: false
+
+documents:
+  - uco-core:id: "urn:uuid:c4f17b95-50da-5f23-a352-3d142f1ee68c"
+    uco-core:name: "NCMEC CyberTipline Data — 2025 CyberTipline Report (public page)"
+
+    # Source location
+    observable:url: "https://www.missingkids.org/cybertiplinedata"
+    observable:filePath: "analytics_demonstration/collected_sources/ncmec-cybertipline-data/source.html"
+
+    collectionAction:
+      uco-core:id: "urn:uuid:d40757a2-0bf4-5a13-861a-0a2688fadf1a"
+      uco-action:startTime: "2026-07-19T05:03:58Z"
+      uco-action:performer: "urn:uuid:b4e0227c-13ba-5997-aa36-d043becda92e"
+      uco-core:description: "manual (HTTP GET via PowerShell Invoke-WebRequest) by CAC Ontology Path A agent; public page only"
+
+    # Raw content metadata (HTML bytes as collected)
+    observable:mimeType: "text/html"
+    observable:sizeInBytes: 725977
+    observable:hash:
+      types:hashMethod: "SHA-256"
+      types:hashValue: "db3cf9214fb28679b5f709ec54a36aff3aa0fa0bd431ae6fff3bb52d75e9e9c4"
+
+    # Intermediate clean extract (full prose, still pre-keypoint)
+    intermediateCleanText:
+      observable:filePath: "analytics_demonstration/collected_sources/ncmec-cybertipline-data/source.txt"
+      observable:mimeType: "text/plain"
+      observable:sizeInBytes: 22420
+      observable:hash:
+        types:hashMethod: "SHA-256"
+        types:hashValue: "4b4e83f0c20e47b3289292441149cf98bbc4d6af622712015a09a2c73b8c95e6"
+
+    # Normalized output (line-stable keypoints for evidence pointers)
+    normalizationAction:
+      uco-core:id: "urn:uuid:d8bb8c02-d826-5735-992f-bc4306e3d092"
+      uco-core:description: "manual_substantive_extract + whitespace_normalize + strip_nav/script/donation chrome + keypoint_normalize (numbered statements)"
+      uco-action:startTime: "2026-07-19T05:03:58Z"
+      uco-action:result: "urn:uuid:7e33c023-a82f-5fe5-b9d1-0b74e3a8513c"
+
+    normalizedOutput:
+      uco-core:id: "urn:uuid:7e33c023-a82f-5fe5-b9d1-0b74e3a8513c"
+      observable:filePath: "analytics_demonstration/collected_sources/ncmec-cybertipline-data/normalized.txt"
+      observable:mimeType: "text/plain"
+      observable:sizeInBytes: 8746
+      observable:hash:
+        types:hashMethod: "SHA-256"
+        types:hashValue: "f0d8b0431066a09a0b5b444f618bf874083ad088c861ade132b23ea891a9a617"
+
+# UUIDs used (UUIDv5 for determinism; document namespace = UUID5(DNS, source URL))
+# DNS NS: 6ba7b810-9dad-11d1-80b4-00c04fd430c8
+# document namespace: 3163ddce-323b-5805-b7d2-89b277787002 = uuid5(DNS, "https://www.missingkids.org/cybertiplinedata")
+uuids:
+  document_namespace: "3163ddce-323b-5805-b7d2-89b277787002"
+  batch: "6e03e099-e6fe-5486-bab5-e498c172459a"
+  raw_doc: "c4f17b95-50da-5f23-a352-3d142f1ee68c"
+  normalized_doc: "7e33c023-a82f-5fe5-b9d1-0b74e3a8513c"
+  collection_action: "d40757a2-0bf4-5a13-861a-0a2688fadf1a"
+  normalization_action: "d8bb8c02-d826-5735-992f-bc4306e3d092"
+  provenance_record: "b29c9903-8cb7-5634-8649-207aebc50295"
+  agent: "b4e0227c-13ba-5997-aa36-d043becda92e"
+
+# Scope decision (Phase 0)
+caseId: "ncmec-cybertipline-data"
+mode: "single-document"
+path: "A"
+output_example_declared: "examples_knowledge_graphs/ncmec-cybertipline-data-example.ttl"
+
+scope:
+  status: "IN_SCOPE"
+  rationale: >
+    Public high-level NCMEC aggregate statistics and program description of CyberTipline
+    operations (reporting categories, ESP/public flows, referrals, hash sharing, domestic/global
+    LE referral, CMT). Maps to existing CAC modules (us-ncmec, hotlines, platforms, partnerships,
+    international, taskforce metrics) without requiring case-level investigative content.
+  categories:
+    - "NCMEC CyberTipline aggregate statistics"
+    - "ESP and public reporting workflows"
+    - "Report triage (referral vs informational)"
+    - "Hash matching and hash sharing"
+    - "Content removal notices"
+    - "Domestic ICAC / federal LE availability"
+    - "International LE and NGO partnerships"
+    - "Case Management Tool (CMT)"
+    - "OJJDP / REPORT Act / 18 USC 2258A legal context (high-level)"
+  excluded_topics:
+    - "Individual victim identities or case dockets (none present on source)"
+    - "CSAM content or file payloads (none present; counts only)"
+    - "Non-public tip detail or investigative holdings"
+    - "Interactive map/chart raw data not exposed as static text (pie charts showing 0 in HTML scrape)"
+    - "Archive PDF link inventories (provenance pointer only; not modeled as primary content)"
+  privacy_harm:
+    - "No named child victims"
+    - "No CSAM imagery or hashes of CSAM files"
+    - "Company names appear only as public NCMEC transparency statements about report quality"
+    - "Suicide statistic retained only as aggregate page statement (no individual identifiers)"
+
+# Candidate modules (Phase 0 ceiling — search-first reuse only; no TBox change default)
+candidate_modules:
+  primary:
+    - "ontology/cacontology-us-ncmec.ttl"
+    - "ontology/cacontology-hotlines.ttl"
+    - "ontology/cacontology-platforms.ttl"
+    - "ontology/cacontology-partnerships.ttl"
+    - "ontology/cacontology-international.ttl"
+    - "ontology/cacontology-taskforce.ttl"
+  secondary_as_needed:
+    - "ontology/cacontology-detection.ttl"
+    - "ontology/cacontology-sextortion.ttl"
+    - "ontology/cacontology-sex-trafficking.ttl"
+    - "ontology/cacontology-sadistic-online-exploitation.ttl"
+    - "ontology/cacontology-ai-csam.ttl"
+    - "ontology/cacontology-prevention.ttl"
+  foundational:
+    - "UCO (identity, action, observable, types)"
+    - "CASE investigation (InvestigativeAction, ProvenanceRecord)"
+  do_not_modify_tbox_default: true
+
+working_assumptions:
+  - "caseId = ncmec-cybertipline-data (kebab-case, source-derived)"
+  - "Single-document Path A; no batch ER / Graph DB required"
+  - "No new classes/properties by default (Phase 3 skip unless governance-justified later)"
+  - "UUIDv5 instance IRIs for deterministic regeneration"
+  - "Model page as public report/listing of aggregate program facts + statement actions, not a fictional case file"
+  - "Prefer statement/listing Actions for statistics rather than inventing individual Cybertip instances for each million reports"
+  - "Interactive charts without numeric text are out of evidence set"
+  - "cac-core spine rules apply to any domain class use; Path A ABox types use domain/UCO/CASE classes"
+  - "Do not commit testing/c* or docker-compose.override.yml"

--- a/analytics_demonstration/collected_sources/ncmec-cybertipline-data/normalized.txt
+++ b/analytics_demonstration/collected_sources/ncmec-cybertipline-data/normalized.txt
@@ -1,0 +1,60 @@
+Source URL: https://www.missingkids.org/cybertiplinedata
+Publisher: National Center for Missing & Exploited Children (NCMEC)
+Title: 2025 CyberTipline Report (public aggregate statistics page)
+Captured (UTC): 2026-07-19T05:03:58Z
+Normalization: manual_substantive_extract + whitespace_normalize + strip_nav_chrome + strip_script_noise + strip_donation_chrome + omit_archive_pdf_link_lists
+
+1) CyberTipline was created in 1998 to receive reports of suspected child sexual exploitation from the public and electronic service providers (ESPs).
+2) CyberTipline is supported by DOJ Office of Juvenile Justice and Delinquency Prevention (OJJDP) and other partners; it assists law enforcement and helps stop harmful circulation of CSAM.
+3) This page reports data from CyberTipline reports made in 2025.
+4) In 2025, the CyberTipline received 21.3 million reports.
+5) In 2025, NCMEC identified and escalated for law enforcement more than 53,000 reports that were urgent or involved a child in imminent danger (via ESP notifications, internal alerts, and manual review of chats/files/other information).
+6) Online enticement reports increased 158% from 2024; child sex trafficking reports increased 323% from 2024.
+7) These category growth trends were impacted by the 2024 REPORT Act, which requires ESPs to report online enticement and child sex trafficking in the same way they report CSAM.
+8) Emerging 2025 trends also include generative AI (GAI) in child sexual exploitation, financial sextortion, and exploitation driven by violent online groups.
+9) CSAM is the largest CyberTipline reporting category; online enticement and child sex trafficking were among the fastest growing categories in 2025.
+10) In 2025, ESP reports contained 61.8 million images, videos, and other files related to the reported child sexual exploitation incident (majority related to suspected CSAM).
+11) File breakdown (2025): 26.3M videos; 29.4M images; 6.1M other files.
+12) Online enticement: individual communicates with someone believed to be a child via the internet with intent to commit a sexual offense or abduction; includes sextortion and grooming pathways across gaming, social media, and messaging apps.
+13) In 2025: 1.4 million online enticement reports, including more than 800 travel-to-meet reports and more than 80,000 sextortion reports.
+14) Financial sextortion is reported under online enticement; 2025 average 137 financial sextortion reports per day (37% increase vs prior year).
+15) NCMEC is aware of at least three dozen teenage boys in the U.S. who died by suicide after financial sextortion victimization (aggregate awareness statement; no individual identifiers on page).
+16) Sadistic online exploitation: more than 3,000 reports in 2025 (>125% increase YoY), largely driven by enhanced industry reporting.
+17) Child sex trafficking CyberTipline reports rose 323% vs 2024; REPORT Act mandated reporting is exposing volume across online platforms.
+18) Observed trafficking patterns: (a) buyers directly targeting children online offering payment for sex acts; (b) increasing overlap between trafficking and CSAM (CSAM as "preview" then in-person exploitation); (c) coordination among multiple offenders online.
+19) 2025 GAI nexus reports: 1.5 million; more than 1.1 million from Amazon AI Services related to potential CSAM in AI training datasets (those submissions lacked actionable offender/victim information).
+20) Excluding Amazon AI training-dataset submissions: more than 182,000 reports involved offenders possessing, generating, or attempting to generate GAI CSAM.
+21) Since 2023 GAI tracking: more than 275 GAI CSAM victims identified; more than 158,000 images/videos categorized as GAI CSAM; "nudify" app peer cases also tracked.
+22) More than 2,000 ESPs registered to report; 23% are non-U.S.-based voluntary reporters.
+23) In 2025: just over 300 companies submitted reports; five ESPs accounted for more than 75% of reports.
+24) 2025 report source split: 170,193 public; 21,181,300 ESP (total 21.3 million).
+25) Public reports: more than 170,000 from members of the public; more than 5,700 reports directly from the victim (>100% increase from 2024).
+26) Take It Down: free hash-based removal-assistance service for explicit imagery of persons under 18; 2025: more than 130,000 submissions covering more than 273,000 images/videos.
+27) As of 2025-12-31, Take It Down available in 36 languages; 2025 site: more than 1.6M visitors and more than 4.2M page views (majority U.S., then India, Brazil, Turkey, Mexico).
+28) Report response: NCMEC makes reports and analysis available to law enforcement for prioritization and notifies companies to locate/remove content.
+29) Referral definition: tech company provides sufficient information for law enforcement (usually user details, imagery, possible location of child or offender).
+30) Informational definition: insufficient information or viral imagery reported many times.
+31) In 2025: more than 18.8 million reports referred to law enforcement; more than 4.5 million designated informational when made available to law enforcement.
+32) More than 10% of tech-industry CyberTipline reports in 2025 lacked adequate information to determine where the offense occurred (blocks jurisdiction-specific referral though all reports available to U.S. federal LE).
+33) Named ESPs (among companies with ≥100 reports) where more than half of reports lacked adequate jurisdictional information: Amazon AI Services; Box, Inc./Box.com; Character Technologies, Inc.; Grindr; Invoke AI, Inc.; Lightspeed Systems; Padlet/Wallwisher, Inc./cloudfront; Redgifs.com; Streamable, Inc.; Wizz App; X.AI LLC; Zoom Video Communications, Inc.
+34) Early 2026: NCMEC observed reporting improvements from Amazon AI Services, Grindr, and X.AI LLC enabling more actionable referrals/notifications.
+35) Unique content (2025): of 29.4M images, 13.9M unique (48%); of 26.3M videos, 7.3M unique (28%).
+36) Example recirculation statement: one child's abusive imagery circulated 20 years and appeared more than 1.4 million times in NCMEC submissions (illustrative aggregate; no personal identifiers).
+37) NCMEC analysts label suspected CSAM for content type, estimated age range, and prioritization cues (e.g., violence, infants/toddlers).
+38) Files labeled: more than 14.6 million in 2025; more than 77.1 million cumulative as of 2025-12-31.
+39) Hash matching automates recognition of previously labeled files to reduce duplicative analyst review and prioritize newer/urgent imagery.
+40) Hash sharing: analysts review image/video at least three times before adding hash to list shared with companies; as of 2025-12-31, more than 12.1 million hashes shared with 78 voluntary ESPs.
+41) Removal notice categories: CSAM; Exploitative (identified victims, may not meet legal CSAM threshold); Predatory Text (predatory comments or personal information about identified victim/survivor).
+42) In 2025: more than 172,000 notices issued; average take-down time 2.6 days.
+43) 18 U.S.C. § 2258A requires U.S. companies to report suspected CSAM, online enticement, or child sex trafficking on their platforms/servers to the CyberTipline.
+44) CyberTipline functions as a global clearinghouse; reports referred to LE throughout the U.S. and around the world.
+45) 2025 geographic origin (upload): 77% outside U.S.; 9% U.S.-based; 14% unknown origin.
+46) Domestic: more than 2 million reports resolved to the U.S. (all 50 states, D.C., Puerto Rico, other territories); 1.9M to a specific state; 153,000 state unknown.
+47) CyberTipline reports made available to ICAC Task Forces and other local/state/federal agencies; state-unknown reports available to federal LE.
+48) Global: partnerships with LE in 170 countries/territories including Interpol and Europol; Interpol assists dissemination where NCMEC lacks direct LE connection.
+49) NGO collaborations named: WeProtect, ECPAT, International Justice Mission (IJM), Internet Watch Foundation, Canadian Centre for Child Protection, UNICEF; NCMEC founding member of INHOPE (50 member hotlines, six continents).
+50) Case Management Tool (CMT): developed with support from OJJDP and Meta; enables secure/quick report sharing with domestic and international LE for triage/prioritization/management.
+51) CMT UI available in eight languages: English, Spanish, French, German, Portuguese, Arabic, Hindi, Thai.
+52) Domestic CMT access includes all ICAC Task Forces, FBI, and Homeland Security Investigations (HSI).
+53) Complementary OJJDP transparency report on 2025 CyberTipline activity prepared in consultation with OJJDP.
+54) Site funding acknowledgment: funded in part through OJJDP / Office of Justice Programs / U.S. Department of Justice grant; DOJ does not operate/control/endorse the website.

--- a/analytics_demonstration/collected_sources/ncmec-cybertipline-data/phase0_guardrails.md
+++ b/analytics_demonstration/collected_sources/ncmec-cybertipline-data/phase0_guardrails.md
@@ -1,0 +1,47 @@
+# Phase 0 Guardrails — ncmec-cybertipline-data
+
+**Chunk:** C2.A1  
+**Mode:** single-document Path A  
+**caseId:** `ncmec-cybertipline-data`  
+**Declared example path:** `examples_knowledge_graphs/ncmec-cybertipline-data-example.ttl`  
+**Collected (UTC):** 2026-07-19T05:03:58Z  
+
+## Working assumptions (locked for C2.A2)
+
+1. Source is **public high-level** NCMEC aggregate CyberTipline statistics (not a prosecution press release, not investigative holdings).
+2. **IN_SCOPE** for domain modeling of program, reporting flows, aggregate metrics, partnerships, and high-level legal citations present on page.
+3. **No new classes/properties by default** — Phase 3 skipped unless a later governance gate proves a strict gap.
+4. Prefer **reuse** from `cacontology-us-ncmec`, hotlines, platforms, partnerships, international, taskforce, plus UCO/CASE foundations.
+5. Prefer **statement/listing Actions** for aggregate statistics rather than synthesizing millions of individual tip instances.
+6. Instance IRIs: **UUIDv5** under document namespace `3163ddce-323b-5805-b7d2-89b277787002`.
+7. Evidence pointers: `normalized.txt` keypoint numbers (1–54).
+8. Domain ABox typing uses existing domain/UCO/CASE classes (not bare `cac-core:` instance types).
+9. Interactive chart values that render as empty/zero in HTML scrape are **not** evidence.
+10. Company names appear only as NCMEC public transparency statements; model carefully with provenance; no defamation-style expansion.
+11. Suicide aggregate awareness statement may be modeled only if grounded and privacy-safe (aggregate, no identifiers); may omit if connectivity cost exceeds signal.
+12. Do not commit `testing/c*` or `docker-compose.override.yml`.
+
+## Scope confirmation
+
+| Decision | Value |
+|---|---|
+| Scope status | **IN_SCOPE** |
+| Boundary status | Public only; no CSAM content; no individual case PII |
+| Path A filter | -1 → 0 → 1 → 2 → **skip 3** → 4 → (5 optional) → 6 → 7 |
+
+## Candidate modules (ceiling, not commitment)
+
+Primary: `cacontology-us-ncmec`, `cacontology-hotlines`, `cacontology-platforms`, `cacontology-partnerships`, `cacontology-international`, `cacontology-taskforce`.  
+Secondary if text-grounded: detection, sextortion, sex-trafficking, sadistic-online-exploitation, ai-csam, prevention.
+
+## Quality gate status (C2.A1)
+
+| Gate | Status |
+|---|---|
+| Public high-level source selected | PASS |
+| Duplicate detection complete | PASS — proceed |
+| Clean text produced | PASS — `source.txt` + `normalized.txt` |
+| Provenance meta complete (URL, time, method, performer, hashes) | PASS — `manifest.yaml` |
+| caseId frozen | PASS — `ncmec-cybertipline-data` |
+| Scope decision recorded | PASS — IN_SCOPE |
+| No ontology/example TTL generated yet | PASS (deferred to C2.A2) |

--- a/analytics_demonstration/collected_sources/ncmec-cybertipline-data/source.txt
+++ b/analytics_demonstration/collected_sources/ncmec-cybertipline-data/source.txt
@@ -1,0 +1,207 @@
+Source URL: https://www.missingkids.org/cybertiplinedata
+Canonical path (page meta): /gethelpnow/cybertipline/cybertiplinedata
+Captured (UTC): 2026-07-19T05:03:58Z
+Publisher: National Center for Missing & Exploited Children (NCMEC)
+Title: CyberTipline Data — 2025 CyberTipline Report
+Document type: Public high-level aggregate statistics and program description
+Collection method: HTTP GET of public HTML (Invoke-WebRequest) + manual substantive text extraction
+Raw HTML path: analytics_demonstration/collected_sources/ncmec-cybertipline-data/source.html
+Raw HTML SHA-256: db3cf9214fb28679b5f709ec54a36aff3aa0fa0bd431ae6fff3bb52d75e9e9c4
+
+================================================================================
+CLEAN TEXT (substantive page content; navigation, scripts, donation chrome omitted)
+================================================================================
+
+2025 CyberTipline Report
+
+NCMEC's CyberTipline was created in 1998 to receive reports of suspected child sexual exploitation from the public and electronic service providers (ESPs). With support from the Department of Justice Office of Juvenile Justice and Delinquency Prevention and other partners, it helps law enforcement efforts to stop child sexual exploitation and abuse and helps stop the harmful circulation of child sexual abuse material (CSAM).
+
+This NCMEC report includes data from reports made to the CyberTipline in 2025 and reflects the latest insights on the threats against children online and the infrastructure put in place to protect them.
+
+## Reports
+
+In 2025, the CyberTipline received 21.3 million reports.
+
+One of the critical functions of the CyberTipline is to assist law enforcement in identifying those reports where the most urgent action is needed in response to a child in critical danger. In 2025, through ESP notifications, internal alerts and manual review of chats, files or other information, NCMEC identified and escalated for law enforcement more than 53,000 reports that were urgent or involved a child in imminent danger.
+
+Trends that stood out this year within the data include the continued growth in the reporting categories of online enticement (158% increase in reports from 2024) and child sex trafficking (323% increase in reports from 2024), both of which were impacted by the 2024 enactment of the REPORT Act, which requires ESPs to report online enticement and child sex trafficking in the same way they report CSAM. Other emerging trends included continued growth in the use of generative artificial intelligence (GAI) in child sexual exploitation, the continued proliferation of financial sextortion cases and the complex forms of sexual exploitation being driven by violent online groups.
+
+Child sex trafficking reports rose 323%.
+
+NCMEC also released guidelines in 2024 for online platforms to help them comply with the new reporting requirements of the REPORT Act.
+
+### Reporting Categories
+
+Child sexual abuse material is the largest reporting category for the CyberTipline, but in 2025, two of the fastest growing reporting categories were online enticement and child sex trafficking.
+
+### Images, Videos & Other Files
+
+Reports made to the CyberTipline by ESPs can include images, videos and other files related to the child sexual exploitation incident being reported. The majority of reported files are related to suspected CSAM.
+
+In 2025, reports from ESPs contained 61.8 million images, videos and other files related to the child sexual exploitation incident being reported.
+
+- 61.8M total files included in 2025 reports to the CyberTipline
+- 26.3M videos
+- 29.4M images
+- 6.1M other files
+
+### Emerging Threats
+
+By identifying trends within the CyberTipline data, we can improve both the response to instances of child sexual exploitation and efforts to prevent harm. The trends that stood out in 2025 include:
+
+#### Online Enticement
+
+In 2025, NCMEC saw a staggering increase in the number of reports the CyberTipline received related to the online enticement of children for sexual acts, which involves an individual communicating with someone believed to be a child via the internet with the intent to commit a sexual offense or abduction. This is a broad category of online exploitation and includes sextortion, in which a child is being groomed to take sexually explicit images or ultimately meet face-to-face with someone for sexual purposes, or to engage in a sexual conversation online or, in some instances, to sell or trade the child's sexual images. This type of victimization takes place across every type of platform, including online gaming, social media and messaging apps. The CyberTipline received 1.4 million reports concerning online enticement in 2025, which included more than 800 reports in which an offender traveled to meet a child in person and more than 80,000 reports concerning sextortion. Within online enticement reports, NCMEC also continued to track the evolving threats of financial sextortion and sadistic online exploitation.
+
+- 1.4M reports of online enticement
+
+#### Financial Sextortion
+
+Financial sextortion is reported under the reporting category of online enticement and in 2025, we continued to see an increase in these cases. Many of them continue to involve teenage boys being targeted by offenders who often use fake social media accounts to convince the boys to send them a nude or sexual image and then immediately begin demanding money. In 2025, NCMEC received an average of 137 reports of financial sextortion a day – a 37% increase in reports daily compared to the year before. Tragically, NCMEC is aware of at least three dozen teenage boys in the U.S. who have taken their lives as a result of being victimized by this crime.
+
+- 137 reports of financial sextortion every day
+
+#### Sadistic Online Exploitation
+
+There has been a continued increase in reports of violent online groups or individuals targeting vulnerable children and encouraging them to harm themselves and others by creating CSAM and sexually exploiting other children. While still a relatively small portion of the overall CyberTipline reports, the extreme harm caused in these cases makes them especially concerning. In 2025, NCMEC's CyberTipline received more than 3,000 reports concerning sadistic online exploitation – a more than 125% increase over last year, largely driven by enhanced industry reporting.
+
+- More than 3,000 reports of sadistic online exploitation
+
+#### Child Sex Trafficking
+
+While the sex trafficking of children online is not a new crime, the mandated reporting required by the REPORT Act for the first time is exposing the pervasiveness of this crime across online platforms. In 2025, reports to the CyberTipline related to child sex trafficking increased by 323% compared to 2024. For years NCMEC had alerted law enforcement, online platforms and members of the public to traffickers' and buyers' overt use of the internet to target, groom, buy and sell children for sex. As a direct result of the REPORT Act, NCMEC is starting to see a more realistic reflection of the volume of children being trafficked for sex online. With this data, we are seeing clear patterns:
+
+- Buyers are directly targeting children, aggressively approaching them online and offering payment for sex acts without an apparent connection to a third-party trafficker, sometimes repeatedly over time.
+- There is increasing overlap between child sex trafficking and child sexual abuse material (CSAM). Offenders first offer to pay a child to produce and send them CSAM as a "preview," then escalate to in-person exploitation to pay the child for sex.
+- We are seeing coordination among offenders, multiple individuals working together online to coordinate the exploitation of a child through sex trafficking.
+
+#### Generative AI
+
+NCMEC continues to hear from many children and families who have been harmed by the use of AI technology in the exploitation of children. Reports to the CyberTipline in 2025 included 1.5 million reports of exploitation with a GAI nexus. Of the total volume, more than 1.1 million reports submitted by Amazon AI Services related to the detection of potential CSAM within AI training datasets. Those reports did not include actionable offender or victim-related information. Excluding those submissions, more than 182,000 reports involved offenders possessing, generating or attempting to generate GAI CSAM, underscoring the increasing role of generative AI in enabling and scaling child sexual exploitation and abuse. This also includes the revictimization of known victims of CSAM with offenders using AI to manipulate existing abusive imagery to create new content. Since 2023, when we started tracking the use of GAI, more than 275 victims of GAI CSAM have been identified, and more than 158,000 images and videos have been categorized as GAI CSAM. Across the country, NCMEC is also tracking cases in which individuals – oftentimes classmates or peers – are leveraging "nudify" apps to create and spread harmful content.
+
+- 158,000 images and videos categorized as GAI CSAM since 2023
+
+### Electronic Service Provider Reports
+
+The CyberTipline receives reports from the public and online electronic service providers (ESPs) with the majority coming from ESPs. To date, more than 2,000 ESPs are registered to make reports, and 23% of these are non-U.S.-based companies that have voluntarily registered to report to the CyberTipline. In 2025, just over 300 companies submitted CyberTipline reports and five ESPs accounted for more than 75% of the reports.
+
+In 2025:
+- 21.3 million CyberTipline reports total
+- 170,193 public reports
+- 21,181,300 ESP reports
+
+### Public Reports
+
+In addition to ESP reports, the CyberTipline received more than 170,000 reports from members of the public regarding suspected child sexual exploitation. Last year, NCMEC's CyberTipline saw an increase in reports from survivors or someone close to them. In 2025, NCMEC's CyberTipline received more than 5,700 reports directly from the victim, which is a more than 100% increase from 2024.
+
+- More than 5,700 reports directly from the victim
+
+In addition to the CyberTipline, NCMEC also offers Take It Down as a free service that helps members of the public who believe explicit imagery of them taken before they were 18 may be shared online. Take It Down assigns a digital marker or hash value to the nude, partially nude or sexually explicit content, and NCMEC provides that list of hash values to participating online platforms. Through voluntary efforts, the platforms can use that hash list to help them detect and remove content. In 2025, NCMEC's Take It Down program received more than 130,000 submissions requesting assistance in removing more than 273,000 images and videos.
+
+- More than 130,000 submissions to Take It Down
+- More than 273,000 images and videos requested for removal assistance
+
+In 2025, Take It Down was translated into three additional languages including Croatian, Serbian and Slovenian. As of December 31, 2025, Take It Down was available in 36 languages and has been promoted to potential users around the world. The Take It Down website recorded more than 1.6 million visitors and more than 4.2 million page views. The majority of website visitors were based in the U.S. followed by India, Brazil, Turkey and Mexico.
+
+## CyberTipline Report Response
+
+NCMEC's response to CyberTipline reports includes making the reports and our additional analysis available to law enforcement to help them prioritize the most urgent cases, as well as providing resources and notification services to companies to help them locate and remove content on their platforms. In 2025, that included:
+
+### Referrals & Informational Reports
+
+NCMEC categorizes CyberTipline reports based on the quantity and quality of information included and whether it can help law enforcement take action:
+
+Referral — A referral is a report in which the tech company provides sufficient information for law enforcement, usually including user details, imagery and a possible location for the child or the offender.
+
+Informational — An informational report is one in which the tech company provides insufficient information or where the imagery is considered viral and has been reported many times.
+
+In 2025, NCMEC referred more than 18.8 million reports to law enforcement and designated more than 4.5 million reports as informational when making them available to law enforcement.
+
+NCMEC notifies companies when their reports consistently lack substantive information.
+
+In 2025, more than 10% of CyberTipline reports submitted by the tech industry contained inadequate information for NCMEC to determine where the offense occurred. While all CyberTipline reports are made available to U.S. federal law enforcement, a lack of jurisdictional information prevents NCMEC from referring a report to a specific agency in the jurisdiction where the incident occurred. Among companies that made at least 100 reports in 2025, more than half of the reports submitted by the companies listed here lacked adequate information to determine the jurisdiction of the offense:
+
+- Amazon AI Services
+- Box, Inc./Box.com
+- Character Technologies, Inc.
+- Grindr
+- Invoke AI, Inc.
+- Lightspeed Systems
+- Padlet/Wallwisher, Inc./cloudfront
+- Redgifs.com
+- Streamable, Inc.
+- Wizz App
+- X.AI LLC
+- Zoom Video Communications, Inc.
+
+In the early months of 2026, NCMEC has already seen significant reporting improvements from Amazon AI Services, Grindr and X.AI LLC, enabling their submissions to result in more actionable referrals to law enforcement or notifications to hosting providers to remove CSAM from their services.
+
+### File Review & Triage
+
+Child sexual abuse images and videos are often circulated and shared online repeatedly. CSAM depicting a single child victim can be circulated for years after the initial abuse occurred. For example, one child's abusive imagery has been circulated for the past 20 years, appearing more than 1.4 million times in submissions to NCMEC. One of the CyberTipline's critical functions is to identify unique images among the reported files through the analysis of NCMEC staff and the use of technology. In 2025, ESPs submitted 29.4 million images to the CyberTipline, of which 13.9 million (48%) were unique. Of the 26.3 million videos reported by ESPs, 7.3 million (28%) were unique.
+
+NCMEC analysts review suspected CSAM submitted by companies and label images and videos with information about the type of content, the estimated age range of the children seen and other details that help law enforcement prioritize the reports for review. For example, labels can indicate if the imagery contains elements such as violence or bestiality or if it involves infants or toddlers.
+
+NCMEC labeled more than 14.6 million files in 2025 and has labeled more than 77.1 million files as of December 31, 2025.
+
+After labeling files, NCMEC's systems use robust hash matching technology to automatically recognize those same images and videos when reported to the CyberTipline in the future. The automated hash matching process reduces the amount of duplicative CSAM that NCMEC staff view and focuses their attention on newer imagery. This process helps ensure the most urgent CyberTipline reports, where a child may be suffering ongoing abuse, get immediate attention.
+
+### Hash Sharing
+
+Hash values are an important tool in stopping the spread of CSAM because they serve as a unique marker for each image and video. NCMEC analysts review an image or video at least three times to confirm that it contains CSAM before adding the hash value to a list that is shared with technology companies.
+
+On a voluntary basis, companies can elect to use NCMEC's hash list to detect CSAM on their systems so that abusive content can be reported and removed. As of December 31, 2025, NCMEC shared more than 12.1 million hashes with 78 ESPs who have voluntarily chosen to access this hash-sharing initiative.
+
+### Removing Content
+
+NCMEC can provide crucial support to child victims by notifying relevant platforms to review and remove any explicit images of the child.
+
+NCMEC staff review the reported imagery and if it falls in one of the three categories below, a notification is made to the ESP where the image or video is located:
+
+- CSAM — Child sexual abuse material, which may violate federal law, a company's terms of service and/or their published community guidelines or standards.
+- Exploitative — Exploitative content, which depicts identified child victims, but the images themselves may not reach the legal threshold of CSAM. Examples are images or videos that contain nudity, non-pornographic content associated with CSAM or otherwise sexually suggestive content of identified child victims.
+- Predatory Text — Text related to sexually predatory comments or personal information about an identified child victim or CSAM survivor. Personal information identifying the child in the image or video may pose safety concerns for the child or survivor.
+
+Based on a company's terms of service, imagery may be removed and/or users blocked in response to a notification. Once a notice has been sent, NCMEC staff track the status of each case and continue to generate additional notices until the content is addressed.
+
+In 2025, NCMEC issued more than 172,000 notices and the average take-down time for images or videos was 2.6 days.
+
+## Domestic & Global Response
+
+A critical function of the CyberTipline is to refer reports to the law enforcement agency that is best able to respond to and address the issue being reported. Federal statute 18 USC 2258A requires U.S. companies to report to the CyberTipline if they become aware of suspected CSAM, online enticement or child sex trafficking on their platforms and servers. Because these companies have users worldwide and those incidents are reported to NCMEC, by extension the CyberTipline serves as a global clearinghouse and reports are referred to law enforcement throughout the U.S. and around the world.
+
+77% of CyberTipline reports in 2025 involved the upload of CSAM or other child sexual exploitation by users outside of the U.S; 9% of CyberTipline reports were U.S.-based and 14% had an unknown origin.
+
+### Domestic Response
+
+While the majority of reports submitted to the CyberTipline resolved outside of the United States, more than 2 million reports resolved to the U.S., including all 50 states, Washington, D.C., Puerto Rico and other U.S. territories. Of these, 1.9 million reports resolved to a specific state and for 153,000 reports, the state was unknown. The CyberTipline reports are made available to Internet Crimes Against Children Task Forces and other local, state and federal agencies. When the state is unknown, the reports are made available to federal law enforcement in the U.S. NCMEC works closely with law enforcement throughout the country, providing training and resources to support their response to CyberTipline reports.
+
+- 1.9M reports resolved to a U.S. state
+
+### Global Response
+
+With more than 77% of reports being referred outside the U.S., NCMEC has forged partnerships with law enforcement in 170 countries and territories that receive CyberTipline reports, including Interpol and Europol. Interpol also assists in the dissemination of CyberTipline report information to certain countries where NCMEC doesn't have a direct connection to law enforcement.
+
+These important connections to law enforcement allow for a quick and seamless referral of CyberTipline reports to help ensure children around the world are safeguarded and offenders are held accountable. A report referred to a single country based on where the content may have been uploaded can still have a nexus with other offenders or victims located in other countries around the world, including the U.S.
+
+With private and public/federal support, NCMEC staff provide CyberTipline trainings in other countries, mentor NGOs seeking to expand technical and operational capacities within their own hotlines, educate on best practices and share child safety and prevention material around the world. We collaborate with dozens of global NGOs, including WeProtect, ECPAT, International Justice Mission (IJM), Internet Watch Foundation, the Canadian Centre for Child Protection, UNICEF and many others. NCMEC is also a founding member of INHOPE, a global network of 50 member hotlines across six continents.
+
+### Case Management Tool
+
+The NCMEC Case Management Tool (CMT), developed with support from the U.S. Office of Juvenile Justice and Delinquency Prevention (OJJDP) and Meta, enables NCMEC to share reports securely and quickly with law enforcement around the world.
+
+The CMT allows law enforcement in the U.S. and abroad to receive, triage, prioritize, organize and manage CyberTipline reports. Through robust and customizable display data, dashboards and metrics, law enforcement personnel can tailor their report queue for more immediate triage and better response.
+
+The CMT also helps police agencies refer reports to other law enforcement agencies for a more targeted response. The system helps NCMEC notify law enforcement of high priority reports.
+
+In support of easier adoption and use by international users, the CMT fields and interface are available in eight languages (English, Spanish, French, German, Portuguese, Arabic, Hindi and Thai). Domestically, all Internet Crimes Against Children Task Forces, the FBI and Homeland Security Investigations also have access.
+
+## OJJDP CT Report
+
+In consultation with the Office of Juvenile Justice and Delinquency Prevention (OJJDP), NCMEC prepared an additional transparency report regarding CyberTipline activity in 2025. It is a complementary resource to the report on this page and contains additional detail about the reports made to the CyberTipline in 2025.
+
+## Funding acknowledgment (footer)
+
+This Web site is funded, in part, through a grant from the Office of Juvenile Justice and Delinquency Prevention, Office of Justice Programs, U.S. Department of Justice. Neither the U.S. Department of Justice nor any of its components operate, control, are responsible for, or necessarily endorse, this Web site (including, without limitation, its content, technical infrastructure, and policies, and any services or tools provided).
+
+Copyright: National Center for Missing & Exploited Children. All rights reserved.

--- a/examples_knowledge_graphs/ncmec-cybertipline-data-example.ttl
+++ b/examples_knowledge_graphs/ncmec-cybertipline-data-example.ttl
@@ -1,0 +1,706 @@
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+@prefix uco-action: <https://ontology.unifiedcyberontology.org/uco/action/> .
+@prefix uco-core: <https://ontology.unifiedcyberontology.org/uco/core/> .
+@prefix uco-identity: <https://ontology.unifiedcyberontology.org/uco/identity/> .
+@prefix uco-observable: <https://ontology.unifiedcyberontology.org/uco/observable/> .
+@prefix uco-types: <https://ontology.unifiedcyberontology.org/uco/types/> .
+@prefix investigation: <https://ontology.caseontology.org/case/investigation/> .
+
+@prefix ex: <urn:uuid:> .
+
+# =============================================================================
+# NCMEC 2025 CyberTipline public aggregate statistics page — Path A example KG
+# caseId: ncmec-cybertipline-data
+# Source: https://www.missingkids.org/cybertiplinedata
+# Collected (UTC): 2026-07-19T05:03:58Z
+# Evidence spans: analytics_demonstration/collected_sources/ncmec-cybertipline-data/normalized.txt (keypoints 1–54)
+# Document namespace (UUIDv5 DNS of source URL): 3163ddce-323b-5805-b7d2-89b277787002
+# Policy: reuse-only ABox; statement/listing Actions for aggregates; no individual tip instances;
+#         no new classes/properties; interactive chart zeros not used as evidence.
+# Validation: Docker pySHACL Conforms (core, us-ncmec, hotlines); ROBOT convert OK; integrity suite OK.
+# =============================================================================
+
+###############################################################################
+# Collection + normalization provenance (manifest-locked UUIDs)
+###############################################################################
+
+ex:c4f17b95-50da-5f23-a352-3d142f1ee68c a uco-observable:ObservableObject ;
+    rdfs:label "NCMEC CyberTipline Data — 2025 CyberTipline Report (public HTML source)"@en ;
+    uco-core:hasFacet ex:cf30ff7d-29e9-5b7d-a09a-6e298c22bf22 ;
+    uco-core:hasFacet ex:dea63d1e-ee69-538f-b6f5-4765196172b8 ;
+    uco-core:hasFacet ex:38f85db4-e3b8-51ad-82f1-2f997bff0b66 ;
+    uco-core:hasFacet ex:0c0927b0-c4f8-5a38-952b-478c8110d1d1 .
+
+ex:cf30ff7d-29e9-5b7d-a09a-6e298c22bf22 a uco-observable:ContentDataFacet ;
+    uco-observable:mimeType "text/html" ;
+    uco-observable:sizeInBytes 725977 .
+
+ex:dea63d1e-ee69-538f-b6f5-4765196172b8 a uco-observable:URLFacet ;
+    uco-observable:url <https://www.missingkids.org/cybertiplinedata> .
+
+ex:0c0927b0-c4f8-5a38-952b-478c8110d1d1 a uco-observable:FileFacet ;
+    uco-observable:filePath "analytics_demonstration/collected_sources/ncmec-cybertipline-data/source.html" .
+
+ex:38f85db4-e3b8-51ad-82f1-2f997bff0b66 a uco-observable:HashFacet ;
+    uco-observable:hash ex:0518d90b-c33c-559d-8cb7-1d48d9833a93 .
+
+ex:0518d90b-c33c-559d-8cb7-1d48d9833a93 a uco-types:Hash ;
+    uco-types:hashMethod "SHA-256" ;
+    uco-types:hashValue "db3cf9214fb28679b5f709ec54a36aff3aa0fa0bd431ae6fff3bb52d75e9e9c4" .
+
+ex:b4e0227c-13ba-5997-aa36-d043becda92e a uco-core:UcoObject ;
+    rdfs:label "CAC Ontology Path A Collection Agent"@en ;
+    uco-core:description "Agent performing public-page collection and keypoint normalization for CAC Ontology Path A ingestion (caseId ncmec-cybertipline-data)."@en .
+
+ex:d40757a2-0bf4-5a13-861a-0a2688fadf1a a investigation:InvestigativeAction ;
+    rdfs:label "Collection action: NCMEC CyberTipline Data public webpage"@en ;
+    uco-action:startTime "2026-07-19T05:03:58Z"^^xsd:dateTime ;
+    uco-action:performer ex:b4e0227c-13ba-5997-aa36-d043becda92e ;
+    uco-action:object ex:c4f17b95-50da-5f23-a352-3d142f1ee68c ;
+    uco-core:description "manual (HTTP GET via PowerShell Invoke-WebRequest) by CAC Ontology Path A agent; public page only. Confidence: high."@en .
+
+ex:d8bb8c02-d826-5735-992f-bc4306e3d092 a uco-action:Action ;
+    rdfs:label "Normalization action: HTML to numbered keypoints (normalized.txt)"@en ;
+    uco-action:startTime "2026-07-19T05:03:58Z"^^xsd:dateTime ;
+    uco-action:performer ex:b4e0227c-13ba-5997-aa36-d043becda92e ;
+    uco-action:object ex:c4f17b95-50da-5f23-a352-3d142f1ee68c ;
+    uco-action:result ex:7e33c023-a82f-5fe5-b9d1-0b74e3a8513c ;
+    uco-core:description "manual_substantive_extract + whitespace_normalize + strip_nav/script/donation chrome + keypoint_normalize (numbered statements 1-54). Confidence: high (deterministic for evidence pointers)."@en .
+
+ex:7e33c023-a82f-5fe5-b9d1-0b74e3a8513c a uco-observable:ObservableObject ;
+    rdfs:label "NCMEC CyberTipline Data page (normalized keypoints)"@en ;
+    uco-core:hasFacet ex:4427d774-1a28-5968-bdbf-fcf61a9eda74 ;
+    uco-core:hasFacet ex:b0539e64-e8fb-59fa-9959-711e8cde0aa6 ;
+    uco-core:hasFacet ex:f291dd89-088e-57a3-875f-e079d2f936eb .
+
+ex:4427d774-1a28-5968-bdbf-fcf61a9eda74 a uco-observable:ContentDataFacet ;
+    uco-observable:mimeType "text/plain" ;
+    uco-observable:sizeInBytes 8746 .
+
+ex:b0539e64-e8fb-59fa-9959-711e8cde0aa6 a uco-observable:FileFacet ;
+    uco-observable:filePath "analytics_demonstration/collected_sources/ncmec-cybertipline-data/normalized.txt" .
+
+ex:f291dd89-088e-57a3-875f-e079d2f936eb a uco-observable:HashFacet ;
+    uco-observable:hash ex:c9031b6a-be09-58f2-99bd-8a00b3e87a8c .
+
+ex:c9031b6a-be09-58f2-99bd-8a00b3e87a8c a uco-types:Hash ;
+    uco-types:hashMethod "SHA-256" ;
+    uco-types:hashValue "f0d8b0431066a09a0b5b444f618bf874083ad088c861ade132b23ea891a9a617" .
+
+ex:b29c9903-8cb7-5634-8649-207aebc50295 a investigation:ProvenanceRecord ;
+    rdfs:label "Provenance record: collection of NCMEC CyberTipline Data public webpage"@en ;
+    investigation:exhibitNumber "DOC-NCMEC-CYBERTIP-DATA-2025-0001" ;
+    uco-core:object ex:c4f17b95-50da-5f23-a352-3d142f1ee68c ;
+    investigation:provenanceRecordAction ex:d40757a2-0bf4-5a13-861a-0a2688fadf1a ;
+    uco-core:description "Evidence pointer: analytics_demonstration/collected_sources/ncmec-cybertipline-data/manifest.yaml + source.html (SHA-256 db3cf921…). Confidence: high."@en .
+
+###############################################################################
+# Core organizations and programs (page-grounded)
+###############################################################################
+
+ex:2f8ad703-8f71-5099-bf53-5c27da6bdc61 a uco-identity:Organization ;
+    rdfs:label "National Center for Missing & Exploited Children (NCMEC)"@en ;
+    uco-core:name "National Center for Missing & Exploited Children" ;
+    uco-core:description "Publisher of the CyberTipline Data public aggregate statistics page; operates CyberTipline. Typed as uco-identity:Organization only (Path A reuse-only); domain dual-type HotlineOrganization deferred to avoid ungrounded capability-property minCount traps."@en .
+
+ex:bb750857-1349-5375-87a8-0b7293e7f2ca a uco-core:UcoObject ;
+    rdfs:label "CyberTipline (NCMEC program)"@en ;
+    uco-core:description "Created in 1998 to receive reports of suspected child sexual exploitation from the public and electronic service providers (ESPs); supported by OJJDP and partners; functions as a global clearinghouse. Typed as program concept (not millions of tip instances)."@en .
+
+ex:8e8e5deb-4049-5711-8730-152415db9c0b a uco-identity:Organization ;
+    rdfs:label "Office of Juvenile Justice and Delinquency Prevention (OJJDP)"@en ;
+    uco-core:description "DOJ component cited as supporting CyberTipline and funding acknowledgment; complementary transparency report noted on page."@en .
+
+ex:3d9e6ca5-45e2-5a44-ad05-bbcdeb82f6dd a uco-identity:Organization ;
+    rdfs:label "U.S. Department of Justice (DOJ)"@en ;
+    uco-core:description "Parent agency for OJJDP funding acknowledgment; page states DOJ does not operate/control/endorse the website."@en .
+
+ex:f7025aa5-5c29-5018-b43f-dda0423f3197 a uco-identity:Organization ;
+    rdfs:label "Federal Bureau of Investigation (FBI)"@en ;
+    uco-core:description "Named among domestic Case Management Tool (CMT) access holders."@en .
+
+ex:8e9c82a1-17cb-51a3-86ef-784fd1701b97 a uco-identity:Organization ;
+    rdfs:label "Homeland Security Investigations (HSI)"@en ;
+    uco-core:description "Named among domestic Case Management Tool (CMT) access holders."@en .
+
+ex:f6a5ebc1-a02e-5987-8c8e-f3d886d3be2e a uco-identity:Organization ;
+    rdfs:label "ICAC Task Forces (domestic CMT access cohort)"@en ;
+    uco-core:description "Page states domestic CMT access includes all ICAC Task Forces; CyberTipline reports made available to ICAC Task Forces and other agencies."@en .
+
+ex:5a2f3bc2-1ad7-5c1f-88a9-47ef23e724a9 a uco-identity:Organization ;
+    rdfs:label "Interpol"@en .
+
+ex:4e980710-bd04-565b-a5be-2351aa404c23 a uco-identity:Organization ;
+    rdfs:label "Europol"@en .
+
+ex:85e96636-7c64-50a3-87a0-9742250dcb72 a uco-identity:Organization ;
+    rdfs:label "WeProtect"@en .
+
+ex:29748b6e-42dd-5eff-b7ed-54fb81166266 a uco-identity:Organization ;
+    rdfs:label "ECPAT"@en .
+
+ex:71f14324-4b8e-5d71-8dc8-142d626a24b0 a uco-identity:Organization ;
+    rdfs:label "International Justice Mission (IJM)"@en .
+
+ex:dbfcbc7c-faeb-5aee-9937-ff26a68bdbd4 a uco-identity:Organization ;
+    rdfs:label "Internet Watch Foundation"@en .
+
+ex:4762413d-bca1-56ff-953a-4432ba8a5eeb a uco-identity:Organization ;
+    rdfs:label "Canadian Centre for Child Protection"@en .
+
+ex:cc3b16d7-35f5-52fb-91a5-8311b64adce9 a uco-identity:Organization ;
+    rdfs:label "UNICEF"@en .
+
+ex:d8e7cda4-9b06-57a9-88f5-1144190b50bb a uco-identity:Organization ;
+    rdfs:label "INHOPE"@en ;
+    uco-core:description "NCMEC founding member; page states 50 member hotlines across six continents."@en .
+
+ex:620494f1-d67b-5045-bdbd-2b04bf6e83cf a uco-identity:Organization ;
+    rdfs:label "Amazon AI Services"@en ;
+    uco-core:name "Amazon AI Services" ;
+    uco-core:description "Named on page for 2025 GAI nexus submissions related to potential CSAM in AI training datasets and for early-2026 reporting improvements. Modeled only as NCMEC public transparency reference (uco-identity:Organization); not dual-typed as ElectronicServiceProvider because page does not ground ESP capability properties required by shapes."@en .
+
+ex:3f61c3ec-5cb5-57eb-9bec-ae32a184a527 a uco-identity:Organization ;
+    rdfs:label "Meta"@en ;
+    uco-core:description "Named as supporting development of Case Management Tool (CMT) with OJJDP."@en .
+
+ex:b26d6498-f3c9-563c-8021-6518eb5116e7 a uco-core:UcoObject ;
+    rdfs:label "Take It Down (NCMEC hash-based removal-assistance service)"@en ;
+    uco-core:description "Free hash-based removal-assistance service for explicit imagery of persons under 18; multi-language availability stated as of 2025-12-31."@en .
+
+ex:72489c87-85b4-5305-8434-53de4a6f986b a uco-core:UcoObject ;
+    rdfs:label "Case Management Tool (CMT)"@en ;
+    uco-core:description "Tool developed with support from OJJDP and Meta; enables secure/quick report sharing with domestic and international LE; UI available in eight languages."@en .
+
+###############################################################################
+# Reporting categories and process concepts (reuse-friendly concept nodes)
+###############################################################################
+
+ex:78c3a9cb-a086-5206-bb9a-01e26c6e2ee7 a uco-core:UcoObject ;
+    rdfs:label "CSAM (largest CyberTipline reporting category)"@en ;
+    uco-core:description "Page states CSAM is the largest CyberTipline reporting category."@en .
+
+ex:56815b6f-4cd0-508f-a41a-624343dad6df a uco-core:UcoObject ;
+    rdfs:label "Online enticement (CyberTipline category)"@en ;
+    uco-core:description "Individual communicates with someone believed to be a child via the internet with intent to commit a sexual offense or abduction; includes sextortion and grooming pathways. Conceptual reuse: us-ncmec OnlineEnticementIncident (category-level claim object, not a case instance)."@en .
+
+ex:c90cd31f-193d-5159-9685-029d72feba0a a uco-core:UcoObject ;
+    rdfs:label "Child sex trafficking (CyberTipline category)"@en ;
+    uco-core:description "Among fastest-growing categories in 2025; REPORT Act mandated ESP reporting. Conceptual reuse: us-ncmec ChildSexTraffickingIncident (category-level claim object)."@en .
+
+ex:76618931-af23-5bd0-92ee-3dff179a0f57 a uco-core:UcoObject ;
+    rdfs:label "Sadistic online exploitation (CyberTipline category)"@en ;
+    uco-core:description "More than 3,000 reports in 2025; largely driven by enhanced industry reporting."@en .
+
+ex:94d8af47-b1ea-5305-81fa-88dfb4446d3d a uco-core:UcoObject ;
+    rdfs:label "Generative AI (GAI) nexus reporting (2025 trend)"@en ;
+    uco-core:description "Emerging 2025 trend: generative AI in child sexual exploitation reporting."@en .
+
+ex:3d8150a6-e9ac-5553-bc05-98561323d889 a uco-core:UcoObject ;
+    rdfs:label "Financial sextortion (reported under online enticement)"@en ;
+    uco-core:description "Reported under online enticement; 2025 average 137 financial sextortion reports per day (37% increase vs prior year)."@en .
+
+ex:bdebaaa4-a87f-5cca-a9f6-3554d49a18c0 a uco-core:UcoObject ;
+    rdfs:label "Referral designation (CyberTipline response)"@en ;
+    uco-core:description "Tech company provides sufficient information for law enforcement (usually user details, imagery, possible location of child or offender)."@en .
+
+ex:63ecc0f9-547f-5a42-9220-256cb03f88a8 a uco-core:UcoObject ;
+    rdfs:label "Informational designation (CyberTipline response)"@en ;
+    uco-core:description "Insufficient information or viral imagery reported many times."@en .
+
+ex:3f77036d-59fb-52c3-b12b-197c199c1c42 a uco-core:UcoObject ;
+    rdfs:label "Hash matching automation (NCMEC analyst workflow)"@en ;
+    uco-core:description "Automates recognition of previously labeled files to reduce duplicative analyst review and prioritize newer/urgent imagery."@en .
+
+ex:cc9aada3-c7c1-57f7-a204-a3b585abc57d a uco-core:UcoObject ;
+    rdfs:label "Hash sharing with voluntary ESPs"@en ;
+    uco-core:description "Analysts review image/video at least three times before adding hash to list shared with companies; as of 2025-12-31 more than 12.1 million hashes shared with 78 voluntary ESPs. Modeled as concept claim object (not HashSharingProtocol instance) to avoid inventing protocol-level properties beyond page text."@en .
+
+ex:49d45d8f-eb73-552c-836f-accc6b78fff6 a uco-core:UcoObject ;
+    rdfs:label "Removal notice categories (CSAM; Exploitative; Predatory Text)"@en ;
+    uco-core:description "CSAM; Exploitative (identified victims, may not meet legal CSAM threshold); Predatory Text (predatory comments or personal information about identified victim/survivor)."@en .
+
+ex:8bc02ae9-233e-56a4-87a7-4e97a1e2acff a uco-core:UcoObject ;
+    rdfs:label "18 U.S.C. § 2258A ESP reporting duty"@en ;
+    uco-core:description "Requires U.S. companies to report suspected CSAM, online enticement, or child sex trafficking on their platforms/servers to the CyberTipline."@en .
+
+ex:ae8837d5-a22c-5c6b-8262-16d74b823917 a uco-core:UcoObject ;
+    rdfs:label "REPORT Act 2024 (impact on category growth)"@en ;
+    uco-core:description "Requires ESPs to report online enticement and child sex trafficking in the same way they report CSAM; page links 2025 category growth trends to this mandate."@en .
+
+ex:7b5bac70-191e-57a4-a038-cf5b3c3bd8c0 a uco-core:UcoObject ;
+    rdfs:label "ESP CyberTipline reporting cohort (2025)"@en ;
+    uco-core:description "Electronic service provider reports to CyberTipline in 2025 (21,181,300 of 21.3M total)."@en .
+
+ex:79eef726-82e4-5741-a67f-0eff172059a8 a uco-core:UcoObject ;
+    rdfs:label "Public CyberTipline reporting cohort (2025)"@en ;
+    uco-core:description "Public reports to CyberTipline in 2025 (170,193 of 21.3M total)."@en .
+
+ex:1fcd9a2f-a3c2-57c3-a77c-50076895d1a7 a uco-core:UcoObject ;
+    rdfs:label "ESPs with majority inadequate jurisdictional information (NCMEC-listed, ≥100 reports)"@en ;
+    uco-core:description "Named on page (among companies with ≥100 reports) where more than half of reports lacked adequate jurisdictional information: Amazon AI Services; Box, Inc./Box.com; Character Technologies, Inc.; Grindr; Invoke AI, Inc.; Lightspeed Systems; Padlet/Wallwisher, Inc./cloudfront; Redgifs.com; Streamable, Inc.; Wizz App; X.AI LLC; Zoom Video Communications, Inc. Modeled as one transparency claim object (no defamation-style expansion beyond page text)."@en .
+
+ex:a770a576-808f-5bf7-aa43-7c0bbd5db9b6 a uco-core:UcoObject ;
+    rdfs:label "Early 2026 reporting improvements (Amazon AI Services, Grindr, X.AI LLC)"@en ;
+    uco-core:description "NCMEC observed reporting improvements enabling more actionable referrals/notifications."@en .
+
+###############################################################################
+# Aggregate statistic claim objects (numbers in description; no tip minting)
+###############################################################################
+
+ex:0be494f1-c542-5e54-84a2-46cbcf9c1fad a uco-core:UcoObject ;
+    rdfs:label "Stat claim: 2025 CyberTipline received 21.3 million reports"@en ;
+    uco-core:description "In 2025, the CyberTipline received 21.3 million reports."@en .
+
+ex:973e4b99-f79e-57bf-bee6-fec52b0822cc a uco-core:UcoObject ;
+    rdfs:label "Stat claim: 2025 urgent/imminent-danger escalations >53,000"@en ;
+    uco-core:description "NCMEC identified and escalated for law enforcement more than 53,000 reports that were urgent or involved a child in imminent danger."@en .
+
+ex:8ee4f05e-5354-595f-aacb-6bf89dc4c1bd a uco-core:UcoObject ;
+    rdfs:label "Stat claim: online enticement +158% vs 2024"@en ;
+    uco-core:description "Online enticement reports increased 158% from 2024."@en .
+
+ex:5b6c03e6-beeb-59ad-ace5-01fd1940d5a8 a uco-core:UcoObject ;
+    rdfs:label "Stat claim: child sex trafficking +323% vs 2024"@en ;
+    uco-core:description "Child sex trafficking reports increased 323% from 2024."@en .
+
+ex:623625a4-d6e3-5068-98e5-2abe570575c5 a uco-core:UcoObject ;
+    rdfs:label "Stat claim: 2025 ESP reports contained 61.8M files"@en ;
+    uco-core:description "ESP reports contained 61.8 million images, videos, and other files related to the reported child sexual exploitation incident (majority related to suspected CSAM)."@en .
+
+ex:df4f5850-9b28-5f7a-b694-f6c060cc4e19 a uco-core:UcoObject ;
+    rdfs:label "Stat claim: 2025 file breakdown 26.3M videos / 29.4M images / 6.1M other"@en ;
+    uco-core:description "File breakdown (2025): 26.3M videos; 29.4M images; 6.1M other files."@en .
+
+ex:b910693a-2d46-5620-be7d-41bcee02c267 a uco-core:UcoObject ;
+    rdfs:label "Stat claim: 2025 online enticement 1.4M reports"@en ;
+    uco-core:description "1.4 million online enticement reports, including more than 800 travel-to-meet reports and more than 80,000 sextortion reports."@en .
+
+ex:51f4e50f-fa19-594a-9d59-3fceeebb25c6 a uco-core:UcoObject ;
+    rdfs:label "Stat claim: 2025 financial sextortion avg 137 reports/day (+37%)"@en ;
+    uco-core:description "2025 average 137 financial sextortion reports per day (37% increase vs prior year)."@en .
+
+ex:5c62f80a-6844-52eb-80af-0fce71c01b9f a uco-core:UcoObject ;
+    rdfs:label "Stat claim: 2025 sadistic online exploitation >3,000 reports (>+125% YoY)"@en ;
+    uco-core:description "More than 3,000 reports in 2025 (>125% increase YoY), largely driven by enhanced industry reporting."@en .
+
+ex:5b56dbaf-c337-559d-a10b-22aff6f418da a uco-core:UcoObject ;
+    rdfs:label "Stat claim: 2025 GAI nexus reports 1.5M"@en ;
+    uco-core:description "2025 GAI nexus reports: 1.5 million; more than 1.1 million from Amazon AI Services related to potential CSAM in AI training datasets (those submissions lacked actionable offender/victim information)."@en .
+
+ex:68d57072-095b-5aa9-a0ed-cd11ea4776f2 a uco-core:UcoObject ;
+    rdfs:label "Stat claim: 2025 GAI offender-related reports >182,000 (excl. Amazon training datasets)"@en ;
+    uco-core:description "Excluding Amazon AI training-dataset submissions: more than 182,000 reports involved offenders possessing, generating, or attempting to generate GAI CSAM."@en .
+
+ex:5da25013-d04d-5df5-8fb1-3a4dfbd88abb a uco-core:UcoObject ;
+    rdfs:label "Stat claim: since 2023 GAI tracking >275 victims; >158,000 GAI CSAM media"@en ;
+    uco-core:description "Since 2023 GAI tracking: more than 275 GAI CSAM victims identified; more than 158,000 images/videos categorized as GAI CSAM."@en .
+
+ex:7d5465d0-06dc-55ca-a30b-7cbad0a75112 a uco-core:UcoObject ;
+    rdfs:label "Stat claim: >2,000 ESPs registered; ~300 companies submitted; five ESPs >75% of reports"@en ;
+    uco-core:description "More than 2,000 ESPs registered to report; 23% non-U.S.-based voluntary reporters; just over 300 companies submitted reports in 2025; five ESPs accounted for more than 75% of reports."@en .
+
+ex:a8a783e6-9aa0-5407-b56d-098a0fea1cd2 a uco-core:UcoObject ;
+    rdfs:label "Stat claim: 2025 source split 170,193 public / 21,181,300 ESP"@en ;
+    uco-core:description "2025 report source split: 170,193 public; 21,181,300 ESP (total 21.3 million)."@en .
+
+ex:9208715b-18c3-59c8-991f-da45092384d5 a uco-core:UcoObject ;
+    rdfs:label "Stat claim: 2025 victim-direct public reports >5,700 (>+100% vs 2024)"@en ;
+    uco-core:description "More than 5,700 reports directly from the victim (>100% increase from 2024)."@en .
+
+ex:14ba4816-ea5e-58b7-99bf-12853bc5b60d a uco-core:UcoObject ;
+    rdfs:label "Stat claim: 2025 Take It Down >130,000 submissions / >273,000 images-videos"@en ;
+    uco-core:description "2025: more than 130,000 submissions covering more than 273,000 images/videos; as of 2025-12-31 available in 36 languages; 2025 site >1.6M visitors and >4.2M page views."@en .
+
+ex:ebbf236e-7b4b-5419-b8c2-955157943435 a uco-core:UcoObject ;
+    rdfs:label "Stat claim: 2025 >18.8M referred / >4.5M informational"@en ;
+    uco-core:description "More than 18.8 million reports referred to law enforcement; more than 4.5 million designated informational when made available to law enforcement."@en .
+
+ex:1d5d3bae-ab65-5800-a698-0e5e03e70e5c a uco-core:UcoObject ;
+    rdfs:label "Stat claim: 2025 >10% tech-industry reports lacked adequate jurisdiction info"@en ;
+    uco-core:description "More than 10% of tech-industry CyberTipline reports in 2025 lacked adequate information to determine where the offense occurred."@en .
+
+ex:cb6ae249-8c95-5a12-a794-6ffd95efdea6 a uco-core:UcoObject ;
+    rdfs:label "Stat claim: 2025 unique content rates (images 48%; videos 28%)"@en ;
+    uco-core:description "Of 29.4M images, 13.9M unique (48%); of 26.3M videos, 7.3M unique (28%). Example recirculation: one child's abusive imagery circulated 20 years and appeared more than 1.4 million times in NCMEC submissions (illustrative aggregate; no personal identifiers)."@en .
+
+ex:61fb695a-291d-5b14-9753-95fc0da9e2e2 a uco-core:UcoObject ;
+    rdfs:label "Stat claim: 2025 files labeled >14.6M; cumulative >77.1M as of 2025-12-31"@en ;
+    uco-core:description "Files labeled: more than 14.6 million in 2025; more than 77.1 million cumulative as of 2025-12-31. Analysts label for content type, estimated age range, and prioritization cues."@en .
+
+ex:05a54441-22be-5211-98c4-9e45fdf18f9c a uco-core:UcoObject ;
+    rdfs:label "Stat claim: as of 2025-12-31 >12.1M hashes shared with 78 voluntary ESPs"@en ;
+    uco-core:description "As of 2025-12-31, more than 12.1 million hashes shared with 78 voluntary ESPs."@en .
+
+ex:8b9422be-a797-52d5-90dd-a38219505d4a a uco-core:UcoObject ;
+    rdfs:label "Stat claim: 2025 >172,000 removal notices; avg take-down 2.6 days"@en ;
+    uco-core:description "In 2025: more than 172,000 notices issued; average take-down time 2.6 days."@en .
+
+ex:ba4b569b-49b0-59b0-a125-f5797a76a5a4 a uco-core:UcoObject ;
+    rdfs:label "Stat claim: 2025 geographic origin of upload 77% outside US / 9% US / 14% unknown"@en ;
+    uco-core:description "2025 geographic origin (upload): 77% outside U.S.; 9% U.S.-based; 14% unknown origin."@en .
+
+ex:7216d0da-8342-59f6-ad26-900d831f0b55 a uco-core:UcoObject ;
+    rdfs:label "Stat claim: 2025 >2M reports resolved to US (1.9M state-specific; 153k state unknown)"@en ;
+    uco-core:description "More than 2 million reports resolved to the U.S. (all 50 states, D.C., Puerto Rico, other territories); 1.9M to a specific state; 153,000 state unknown."@en .
+
+###############################################################################
+# Statement / listing Actions + ProvenanceRecords (normalized.txt keypoints)
+###############################################################################
+
+# --- Program description (keypoints 1-3, 28, 44) ---
+ex:d7455b2a-8cc8-5381-a1a5-ba7ecd919f3c a uco-action:Action ;
+    rdfs:label "Page describes CyberTipline program purpose and 2025 reporting scope"@en ;
+    uco-action:startTime "2026-07-19T05:03:58Z"^^xsd:dateTime ;
+    uco-action:performer ex:2f8ad703-8f71-5099-bf53-5c27da6bdc61 ;
+    uco-action:object ex:7e33c023-a82f-5fe5-b9d1-0b74e3a8513c ,
+                    ex:bb750857-1349-5375-87a8-0b7293e7f2ca ,
+                    ex:8e8e5deb-4049-5711-8730-152415db9c0b ;
+    uco-core:description "Grounded in normalized.txt keypoints 1-3, 28, 44. Confidence: high. CyberTipline created 1998; OJJDP-supported; page reports 2025 data; LE assistance and global clearinghouse role."@en .
+
+ex:dedfa660-9b28-5e5a-992a-a4a1d67f0615 a investigation:ProvenanceRecord ;
+    rdfs:label "Provenance: CyberTipline program description"@en ;
+    uco-core:object ex:7e33c023-a82f-5fe5-b9d1-0b74e3a8513c ;
+    investigation:provenanceRecordAction ex:d7455b2a-8cc8-5381-a1a5-ba7ecd919f3c ;
+    uco-core:description "Evidence pointer: normalized.txt keypoints 1-3, 28, 44."@en .
+
+# --- 2025 volume totals (keypoints 4-5) ---
+ex:2219e4cf-db31-5894-b437-969ac3001ddc a uco-action:Action ;
+    rdfs:label "Page states 2025 CyberTipline volume totals and urgent escalations"@en ;
+    uco-action:startTime "2026-07-19T05:03:58Z"^^xsd:dateTime ;
+    uco-action:performer ex:2f8ad703-8f71-5099-bf53-5c27da6bdc61 ;
+    uco-action:object ex:7e33c023-a82f-5fe5-b9d1-0b74e3a8513c ,
+                    ex:bb750857-1349-5375-87a8-0b7293e7f2ca ,
+                    ex:0be494f1-c542-5e54-84a2-46cbcf9c1fad ,
+                    ex:973e4b99-f79e-57bf-bee6-fec52b0822cc ;
+    uco-core:description "Grounded in normalized.txt keypoints 4-5. Confidence: high. 21.3M reports; >53,000 urgent/imminent-danger escalations."@en .
+
+ex:ffca5378-ad08-5080-b083-1809a7d9d0a9 a investigation:ProvenanceRecord ;
+    rdfs:label "Provenance: 2025 volume totals"@en ;
+    uco-core:object ex:7e33c023-a82f-5fe5-b9d1-0b74e3a8513c ;
+    investigation:provenanceRecordAction ex:2219e4cf-db31-5894-b437-969ac3001ddc ;
+    uco-core:description "Evidence pointer: normalized.txt keypoints 4-5."@en .
+
+# --- Category growth + REPORT Act (keypoints 6-9, 17) ---
+ex:98dc1013-8947-5672-a7ef-090a68de033d a uco-action:Action ;
+    rdfs:label "Page states 2025 category growth trends and REPORT Act impact"@en ;
+    uco-action:startTime "2026-07-19T05:03:58Z"^^xsd:dateTime ;
+    uco-action:performer ex:2f8ad703-8f71-5099-bf53-5c27da6bdc61 ;
+    uco-action:object ex:7e33c023-a82f-5fe5-b9d1-0b74e3a8513c ,
+                    ex:78c3a9cb-a086-5206-bb9a-01e26c6e2ee7 ,
+                    ex:56815b6f-4cd0-508f-a41a-624343dad6df ,
+                    ex:c90cd31f-193d-5159-9685-029d72feba0a ,
+                    ex:8ee4f05e-5354-595f-aacb-6bf89dc4c1bd ,
+                    ex:5b6c03e6-beeb-59ad-ace5-01fd1940d5a8 ,
+                    ex:ae8837d5-a22c-5c6b-8262-16d74b823917 ;
+    uco-core:description "Grounded in normalized.txt keypoints 6-9, 17. Confidence: high. Enticement +158%; trafficking +323%; CSAM largest category; REPORT Act drives ESP reporting parity for enticement/trafficking."@en .
+
+ex:775d9fe1-9f96-55e6-999f-adbce0c5e763 a investigation:ProvenanceRecord ;
+    rdfs:label "Provenance: category growth and REPORT Act"@en ;
+    uco-core:object ex:7e33c023-a82f-5fe5-b9d1-0b74e3a8513c ;
+    investigation:provenanceRecordAction ex:98dc1013-8947-5672-a7ef-090a68de033d ;
+    uco-core:description "Evidence pointer: normalized.txt keypoints 6-9, 17."@en .
+
+# --- File volumes (keypoints 10-11) ---
+ex:40e236f9-270d-5f5e-908d-30c1e0dc265c a uco-action:Action ;
+    rdfs:label "Page states 2025 ESP file volumes and media type breakdown"@en ;
+    uco-action:startTime "2026-07-19T05:03:58Z"^^xsd:dateTime ;
+    uco-action:performer ex:2f8ad703-8f71-5099-bf53-5c27da6bdc61 ;
+    uco-action:object ex:7e33c023-a82f-5fe5-b9d1-0b74e3a8513c ,
+                    ex:623625a4-d6e3-5068-98e5-2abe570575c5 ,
+                    ex:df4f5850-9b28-5f7a-b694-f6c060cc4e19 ;
+    uco-core:description "Grounded in normalized.txt keypoints 10-11. Confidence: high."@en .
+
+ex:f1e7e421-da7a-5c2a-8505-00aa16a88d54 a investigation:ProvenanceRecord ;
+    rdfs:label "Provenance: 2025 ESP file volumes"@en ;
+    uco-core:object ex:7e33c023-a82f-5fe5-b9d1-0b74e3a8513c ;
+    investigation:provenanceRecordAction ex:40e236f9-270d-5f5e-908d-30c1e0dc265c ;
+    uco-core:description "Evidence pointer: normalized.txt keypoints 10-11."@en .
+
+# --- Online enticement + financial sextortion (keypoints 12-14; omit 15 suicide detail) ---
+ex:6c63ca3f-3dd9-5b25-b166-b0c5626fd3cc a uco-action:Action ;
+    rdfs:label "Page states online enticement definition and 2025 enticement/sextortion volumes"@en ;
+    uco-action:startTime "2026-07-19T05:03:58Z"^^xsd:dateTime ;
+    uco-action:performer ex:2f8ad703-8f71-5099-bf53-5c27da6bdc61 ;
+    uco-action:object ex:7e33c023-a82f-5fe5-b9d1-0b74e3a8513c ,
+                    ex:56815b6f-4cd0-508f-a41a-624343dad6df ,
+                    ex:3d8150a6-e9ac-5553-bc05-98561323d889 ,
+                    ex:b910693a-2d46-5620-be7d-41bcee02c267 ,
+                    ex:51f4e50f-fa19-594a-9d59-3fceeebb25c6 ;
+    uco-core:description "Grounded in normalized.txt keypoints 12-14. Confidence: high. Deliberately omits keypoint 15 (suicide awareness aggregate) to minimize harm surface while retaining category metrics."@en .
+
+ex:681c52bc-074a-5faa-ab88-37768a2893a3 a investigation:ProvenanceRecord ;
+    rdfs:label "Provenance: online enticement and financial sextortion volumes"@en ;
+    uco-core:object ex:7e33c023-a82f-5fe5-b9d1-0b74e3a8513c ;
+    investigation:provenanceRecordAction ex:6c63ca3f-3dd9-5b25-b166-b0c5626fd3cc ;
+    uco-core:description "Evidence pointer: normalized.txt keypoints 12-14."@en .
+
+# --- SOE volume (keypoint 16) ---
+ex:176bebef-5709-57d6-8cbb-73eb82d7911e a uco-action:Action ;
+    rdfs:label "Page states 2025 sadistic online exploitation report volume"@en ;
+    uco-action:startTime "2026-07-19T05:03:58Z"^^xsd:dateTime ;
+    uco-action:performer ex:2f8ad703-8f71-5099-bf53-5c27da6bdc61 ;
+    uco-action:object ex:7e33c023-a82f-5fe5-b9d1-0b74e3a8513c ,
+                    ex:76618931-af23-5bd0-92ee-3dff179a0f57 ,
+                    ex:5c62f80a-6844-52eb-80af-0fce71c01b9f ;
+    uco-core:description "Grounded in normalized.txt keypoint 16. Confidence: high."@en .
+
+ex:523ef447-68c7-5770-afed-8261ad7b9412 a investigation:ProvenanceRecord ;
+    rdfs:label "Provenance: sadistic online exploitation volume"@en ;
+    uco-core:object ex:7e33c023-a82f-5fe5-b9d1-0b74e3a8513c ;
+    investigation:provenanceRecordAction ex:176bebef-5709-57d6-8cbb-73eb82d7911e ;
+    uco-core:description "Evidence pointer: normalized.txt keypoint 16."@en .
+
+# --- Trafficking patterns (keypoints 17-18) ---
+ex:2d827359-51be-5471-92f9-d68ae2b096b4 a uco-action:Action ;
+    rdfs:label "Page states observed 2025 child sex trafficking CyberTipline patterns"@en ;
+    uco-action:startTime "2026-07-19T05:03:58Z"^^xsd:dateTime ;
+    uco-action:performer ex:2f8ad703-8f71-5099-bf53-5c27da6bdc61 ;
+    uco-action:object ex:7e33c023-a82f-5fe5-b9d1-0b74e3a8513c ,
+                    ex:c90cd31f-193d-5159-9685-029d72feba0a ,
+                    ex:5b6c03e6-beeb-59ad-ace5-01fd1940d5a8 ;
+    uco-core:description "Grounded in normalized.txt keypoints 17-18. Confidence: high. Patterns: buyers targeting children online; trafficking-CSAM overlap; multi-offender coordination."@en .
+
+ex:5daa42f0-ec8d-579a-a1b9-903028d2b8a0 a investigation:ProvenanceRecord ;
+    rdfs:label "Provenance: trafficking growth and patterns"@en ;
+    uco-core:object ex:7e33c023-a82f-5fe5-b9d1-0b74e3a8513c ;
+    investigation:provenanceRecordAction ex:2d827359-51be-5471-92f9-d68ae2b096b4 ;
+    uco-core:description "Evidence pointer: normalized.txt keypoints 17-18."@en .
+
+# --- GAI nexus (keypoints 8, 19-21) ---
+ex:85d4000b-d5b9-5fbb-a399-1c1d7345b46b a uco-action:Action ;
+    rdfs:label "Page states 2025 generative AI nexus CyberTipline statistics"@en ;
+    uco-action:startTime "2026-07-19T05:03:58Z"^^xsd:dateTime ;
+    uco-action:performer ex:2f8ad703-8f71-5099-bf53-5c27da6bdc61 ;
+    uco-action:object ex:7e33c023-a82f-5fe5-b9d1-0b74e3a8513c ,
+                    ex:94d8af47-b1ea-5305-81fa-88dfb4446d3d ,
+                    ex:620494f1-d67b-5045-bdbd-2b04bf6e83cf ,
+                    ex:5b56dbaf-c337-559d-a10b-22aff6f418da ,
+                    ex:68d57072-095b-5aa9-a0ed-cd11ea4776f2 ,
+                    ex:5da25013-d04d-5df5-8fb1-3a4dfbd88abb ;
+    uco-core:description "Grounded in normalized.txt keypoints 8, 19-21. Confidence: high. Amazon AI Services named only as NCMEC public transparency statement about training-dataset submissions."@en .
+
+ex:5f9d09f0-af39-5cce-b5ae-b060b65796ce a investigation:ProvenanceRecord ;
+    rdfs:label "Provenance: generative AI nexus statistics"@en ;
+    uco-core:object ex:7e33c023-a82f-5fe5-b9d1-0b74e3a8513c ;
+    investigation:provenanceRecordAction ex:85d4000b-d5b9-5fbb-a399-1c1d7345b46b ;
+    uco-core:description "Evidence pointer: normalized.txt keypoints 8, 19-21."@en .
+
+# --- ESP / public sources (keypoints 22-25) ---
+ex:5fd0b382-c2e1-52ac-868b-f1890cef8a1b a uco-action:Action ;
+    rdfs:label "Page states 2025 ESP registration, concentration, and public vs ESP source split"@en ;
+    uco-action:startTime "2026-07-19T05:03:58Z"^^xsd:dateTime ;
+    uco-action:performer ex:2f8ad703-8f71-5099-bf53-5c27da6bdc61 ;
+    uco-action:object ex:7e33c023-a82f-5fe5-b9d1-0b74e3a8513c ,
+                    ex:7b5bac70-191e-57a4-a038-cf5b3c3bd8c0 ,
+                    ex:79eef726-82e4-5741-a67f-0eff172059a8 ,
+                    ex:7d5465d0-06dc-55ca-a30b-7cbad0a75112 ,
+                    ex:a8a783e6-9aa0-5407-b56d-098a0fea1cd2 ,
+                    ex:9208715b-18c3-59c8-991f-da45092384d5 ;
+    uco-core:description "Grounded in normalized.txt keypoints 22-25. Confidence: high."@en .
+
+ex:fec1cc7f-ce8f-5b77-ae07-124a695c414a a investigation:ProvenanceRecord ;
+    rdfs:label "Provenance: ESP/public reporting sources"@en ;
+    uco-core:object ex:7e33c023-a82f-5fe5-b9d1-0b74e3a8513c ;
+    investigation:provenanceRecordAction ex:5fd0b382-c2e1-52ac-868b-f1890cef8a1b ;
+    uco-core:description "Evidence pointer: normalized.txt keypoints 22-25."@en .
+
+# --- Take It Down (keypoints 26-27) ---
+ex:f5d2417b-e949-5ff7-99d4-8ae1b65c7558 a uco-action:Action ;
+    rdfs:label "Page states Take It Down service description and 2025 usage metrics"@en ;
+    uco-action:startTime "2026-07-19T05:03:58Z"^^xsd:dateTime ;
+    uco-action:performer ex:2f8ad703-8f71-5099-bf53-5c27da6bdc61 ;
+    uco-action:object ex:7e33c023-a82f-5fe5-b9d1-0b74e3a8513c ,
+                    ex:b26d6498-f3c9-563c-8021-6518eb5116e7 ,
+                    ex:14ba4816-ea5e-58b7-99bf-12853bc5b60d ;
+    uco-core:description "Grounded in normalized.txt keypoints 26-27. Confidence: high."@en .
+
+ex:60c3c366-826d-5be9-bf9a-9ce65f06e932 a investigation:ProvenanceRecord ;
+    rdfs:label "Provenance: Take It Down"@en ;
+    uco-core:object ex:7e33c023-a82f-5fe5-b9d1-0b74e3a8513c ;
+    investigation:provenanceRecordAction ex:f5d2417b-e949-5ff7-99d4-8ae1b65c7558 ;
+    uco-core:description "Evidence pointer: normalized.txt keypoints 26-27."@en .
+
+# --- Referral vs informational (keypoints 28-32) ---
+ex:29b0998a-713b-595f-8e59-8428d22c05ba a uco-action:Action ;
+    rdfs:label "Page defines referral vs informational designations and 2025 volumes"@en ;
+    uco-action:startTime "2026-07-19T05:03:58Z"^^xsd:dateTime ;
+    uco-action:performer ex:2f8ad703-8f71-5099-bf53-5c27da6bdc61 ;
+    uco-action:object ex:7e33c023-a82f-5fe5-b9d1-0b74e3a8513c ,
+                    ex:bdebaaa4-a87f-5cca-a9f6-3554d49a18c0 ,
+                    ex:63ecc0f9-547f-5a42-9220-256cb03f88a8 ,
+                    ex:ebbf236e-7b4b-5419-b8c2-955157943435 ,
+                    ex:1d5d3bae-ab65-5800-a698-0e5e03e70e5c ;
+    uco-core:description "Grounded in normalized.txt keypoints 28-32. Confidence: high."@en .
+
+ex:fd3987d1-0758-5346-9c42-77bb0bf4dafa a investigation:ProvenanceRecord ;
+    rdfs:label "Provenance: referral vs informational designations"@en ;
+    uco-core:object ex:7e33c023-a82f-5fe5-b9d1-0b74e3a8513c ;
+    investigation:provenanceRecordAction ex:29b0998a-713b-595f-8e59-8428d22c05ba ;
+    uco-core:description "Evidence pointer: normalized.txt keypoints 28-32."@en .
+
+# --- Inadequate jurisdiction transparency (keypoints 33-34) ---
+ex:62a945f0-50dc-5ea8-b7a0-475c067d83f1 a uco-action:Action ;
+    rdfs:label "Page lists ESPs with majority inadequate jurisdictional information and early-2026 improvements"@en ;
+    uco-action:startTime "2026-07-19T05:03:58Z"^^xsd:dateTime ;
+    uco-action:performer ex:2f8ad703-8f71-5099-bf53-5c27da6bdc61 ;
+    uco-action:object ex:7e33c023-a82f-5fe5-b9d1-0b74e3a8513c ,
+                    ex:1fcd9a2f-a3c2-57c3-a77c-50076895d1a7 ,
+                    ex:a770a576-808f-5bf7-aa43-7c0bbd5db9b6 ,
+                    ex:620494f1-d67b-5045-bdbd-2b04bf6e83cf ;
+    uco-core:description "Grounded in normalized.txt keypoints 33-34. Confidence: high. Company names retained only as NCMEC public transparency statements; no expansion beyond page text."@en .
+
+ex:827c3228-4a47-5212-b8b6-e4fb1fd5dd61 a investigation:ProvenanceRecord ;
+    rdfs:label "Provenance: inadequate jurisdiction transparency list"@en ;
+    uco-core:object ex:7e33c023-a82f-5fe5-b9d1-0b74e3a8513c ;
+    investigation:provenanceRecordAction ex:62a945f0-50dc-5ea8-b7a0-475c067d83f1 ;
+    uco-core:description "Evidence pointer: normalized.txt keypoints 33-34."@en .
+
+# --- Unique content + labeling (keypoints 35-38) ---
+ex:771af52c-8ae4-57a3-8f15-9bc8891eecbb a uco-action:Action ;
+    rdfs:label "Page states 2025 unique content rates and analyst labeling volumes"@en ;
+    uco-action:startTime "2026-07-19T05:03:58Z"^^xsd:dateTime ;
+    uco-action:performer ex:2f8ad703-8f71-5099-bf53-5c27da6bdc61 ;
+    uco-action:object ex:7e33c023-a82f-5fe5-b9d1-0b74e3a8513c ,
+                    ex:cb6ae249-8c95-5a12-a794-6ffd95efdea6 ,
+                    ex:61fb695a-291d-5b14-9753-95fc0da9e2e2 ;
+    uco-core:description "Grounded in normalized.txt keypoints 35-38. Confidence: high."@en .
+
+ex:4971ffea-ec16-53a5-868c-79767db27693 a investigation:ProvenanceRecord ;
+    rdfs:label "Provenance: unique content and labeling"@en ;
+    uco-core:object ex:7e33c023-a82f-5fe5-b9d1-0b74e3a8513c ;
+    investigation:provenanceRecordAction ex:771af52c-8ae4-57a3-8f15-9bc8891eecbb ;
+    uco-core:description "Evidence pointer: normalized.txt keypoints 35-38."@en .
+
+# --- Hash matching + sharing (keypoints 39-40) ---
+ex:8eb57fcd-970a-51dc-aea2-4c70d9f6ca70 a uco-action:Action ;
+    rdfs:label "Page states hash matching automation and hash sharing with voluntary ESPs"@en ;
+    uco-action:startTime "2026-07-19T05:03:58Z"^^xsd:dateTime ;
+    uco-action:performer ex:2f8ad703-8f71-5099-bf53-5c27da6bdc61 ;
+    uco-action:object ex:7e33c023-a82f-5fe5-b9d1-0b74e3a8513c ,
+                    ex:3f77036d-59fb-52c3-b12b-197c199c1c42 ,
+                    ex:cc9aada3-c7c1-57f7-a204-a3b585abc57d ,
+                    ex:05a54441-22be-5211-98c4-9e45fdf18f9c ;
+    uco-core:description "Grounded in normalized.txt keypoints 39-40. Confidence: high."@en .
+
+ex:b1494f2c-88c0-55a9-a6d3-10dd590485da a investigation:ProvenanceRecord ;
+    rdfs:label "Provenance: hash matching and sharing"@en ;
+    uco-core:object ex:7e33c023-a82f-5fe5-b9d1-0b74e3a8513c ;
+    investigation:provenanceRecordAction ex:8eb57fcd-970a-51dc-aea2-4c70d9f6ca70 ;
+    uco-core:description "Evidence pointer: normalized.txt keypoints 39-40."@en .
+
+# --- Removal notices (keypoints 41-42) ---
+ex:ec18c68f-a4a6-57f8-9119-656a58d8a3b4 a uco-action:Action ;
+    rdfs:label "Page states removal notice categories and 2025 notice/takedown metrics"@en ;
+    uco-action:startTime "2026-07-19T05:03:58Z"^^xsd:dateTime ;
+    uco-action:performer ex:2f8ad703-8f71-5099-bf53-5c27da6bdc61 ;
+    uco-action:object ex:7e33c023-a82f-5fe5-b9d1-0b74e3a8513c ,
+                    ex:49d45d8f-eb73-552c-836f-accc6b78fff6 ,
+                    ex:8b9422be-a797-52d5-90dd-a38219505d4a ;
+    uco-core:description "Grounded in normalized.txt keypoints 41-42. Confidence: high."@en .
+
+ex:482c401c-2b9e-5098-838b-4ed404cf27d4 a investigation:ProvenanceRecord ;
+    rdfs:label "Provenance: removal notices"@en ;
+    uco-core:object ex:7e33c023-a82f-5fe5-b9d1-0b74e3a8513c ;
+    investigation:provenanceRecordAction ex:ec18c68f-a4a6-57f8-9119-656a58d8a3b4 ;
+    uco-core:description "Evidence pointer: normalized.txt keypoints 41-42."@en .
+
+# --- Legal framework 2258A (keypoint 43) ---
+ex:89769dd5-7522-5d63-a74e-fcea411e09d1 a uco-action:Action ;
+    rdfs:label "Page states 18 U.S.C. § 2258A ESP reporting duty"@en ;
+    uco-action:startTime "2026-07-19T05:03:58Z"^^xsd:dateTime ;
+    uco-action:performer ex:2f8ad703-8f71-5099-bf53-5c27da6bdc61 ;
+    uco-action:object ex:7e33c023-a82f-5fe5-b9d1-0b74e3a8513c ,
+                    ex:8bc02ae9-233e-56a4-87a7-4e97a1e2acff ,
+                    ex:bb750857-1349-5375-87a8-0b7293e7f2ca ;
+    uco-core:description "Grounded in normalized.txt keypoint 43. Confidence: high."@en .
+
+ex:3afc30cc-bc56-5ad2-9ac8-81847262917f a investigation:ProvenanceRecord ;
+    rdfs:label "Provenance: 18 U.S.C. § 2258A statement"@en ;
+    uco-core:object ex:7e33c023-a82f-5fe5-b9d1-0b74e3a8513c ;
+    investigation:provenanceRecordAction ex:89769dd5-7522-5d63-a74e-fcea411e09d1 ;
+    uco-core:description "Evidence pointer: normalized.txt keypoint 43."@en .
+
+# --- Geography domestic/global (keypoints 45-48) ---
+ex:761034db-57bf-5588-9620-2e5baa5fc23d a uco-action:Action ;
+    rdfs:label "Page states 2025 geographic origin, domestic resolution, and global LE partnerships"@en ;
+    uco-action:startTime "2026-07-19T05:03:58Z"^^xsd:dateTime ;
+    uco-action:performer ex:2f8ad703-8f71-5099-bf53-5c27da6bdc61 ;
+    uco-action:object ex:7e33c023-a82f-5fe5-b9d1-0b74e3a8513c ,
+                    ex:ba4b569b-49b0-59b0-a125-f5797a76a5a4 ,
+                    ex:7216d0da-8342-59f6-ad26-900d831f0b55 ,
+                    ex:f6a5ebc1-a02e-5987-8c8e-f3d886d3be2e ,
+                    ex:5a2f3bc2-1ad7-5c1f-88a9-47ef23e724a9 ,
+                    ex:4e980710-bd04-565b-a5be-2351aa404c23 ;
+    uco-core:description "Grounded in normalized.txt keypoints 45-48. Confidence: high. Partnerships with LE in 170 countries/territories including Interpol and Europol."@en .
+
+ex:b70433c0-44ac-558c-9dce-5c7eec8ac1c2 a investigation:ProvenanceRecord ;
+    rdfs:label "Provenance: geography and global LE partnerships"@en ;
+    uco-core:object ex:7e33c023-a82f-5fe5-b9d1-0b74e3a8513c ;
+    investigation:provenanceRecordAction ex:761034db-57bf-5588-9620-2e5baa5fc23d ;
+    uco-core:description "Evidence pointer: normalized.txt keypoints 45-48."@en .
+
+# --- NGO + LE partnerships listing (keypoints 48-49) ---
+ex:9bc233d2-6686-5855-b5cf-8a2328c02e28 a uco-action:Action ;
+    rdfs:label "Page lists NGO collaborations and INHOPE membership"@en ;
+    uco-action:startTime "2026-07-19T05:03:58Z"^^xsd:dateTime ;
+    uco-action:performer ex:2f8ad703-8f71-5099-bf53-5c27da6bdc61 ;
+    uco-action:object ex:7e33c023-a82f-5fe5-b9d1-0b74e3a8513c ,
+                    ex:85e96636-7c64-50a3-87a0-9742250dcb72 ,
+                    ex:29748b6e-42dd-5eff-b7ed-54fb81166266 ,
+                    ex:71f14324-4b8e-5d71-8dc8-142d626a24b0 ,
+                    ex:dbfcbc7c-faeb-5aee-9937-ff26a68bdbd4 ,
+                    ex:4762413d-bca1-56ff-953a-4432ba8a5eeb ,
+                    ex:cc3b16d7-35f5-52fb-91a5-8311b64adce9 ,
+                    ex:d8e7cda4-9b06-57a9-88f5-1144190b50bb ;
+    uco-core:description "Grounded in normalized.txt keypoint 49 (and 48 for Interpol/Europol context). Confidence: high. Named: WeProtect, ECPAT, IJM, Internet Watch Foundation, Canadian Centre for Child Protection, UNICEF; NCMEC founding member of INHOPE."@en .
+
+ex:e9170e73-0618-5a60-8ae9-4a5f0931fd2c a investigation:ProvenanceRecord ;
+    rdfs:label "Provenance: NGO and hotline network partnerships"@en ;
+    uco-core:object ex:7e33c023-a82f-5fe5-b9d1-0b74e3a8513c ;
+    investigation:provenanceRecordAction ex:9bc233d2-6686-5855-b5cf-8a2328c02e28 ;
+    uco-core:description "Evidence pointer: normalized.txt keypoint 49."@en .
+
+# --- CMT (keypoints 50-52) ---
+ex:a73cd004-e283-5e9a-8cd1-a2e8833a2fba a uco-action:Action ;
+    rdfs:label "Page states Case Management Tool (CMT) purpose, languages, and domestic access"@en ;
+    uco-action:startTime "2026-07-19T05:03:58Z"^^xsd:dateTime ;
+    uco-action:performer ex:2f8ad703-8f71-5099-bf53-5c27da6bdc61 ;
+    uco-action:object ex:7e33c023-a82f-5fe5-b9d1-0b74e3a8513c ,
+                    ex:72489c87-85b4-5305-8434-53de4a6f986b ,
+                    ex:8e8e5deb-4049-5711-8730-152415db9c0b ,
+                    ex:3f61c3ec-5cb5-57eb-9bec-ae32a184a527 ,
+                    ex:f6a5ebc1-a02e-5987-8c8e-f3d886d3be2e ,
+                    ex:f7025aa5-5c29-5018-b43f-dda0423f3197 ,
+                    ex:8e9c82a1-17cb-51a3-86ef-784fd1701b97 ;
+    uco-core:description "Grounded in normalized.txt keypoints 50-52. Confidence: high. CMT developed with OJJDP and Meta support; eight UI languages; domestic access includes all ICAC Task Forces, FBI, and HSI."@en .
+
+ex:d5701c3a-ee1e-5795-b889-9b84e702abbc a investigation:ProvenanceRecord ;
+    rdfs:label "Provenance: Case Management Tool (CMT)"@en ;
+    uco-core:object ex:7e33c023-a82f-5fe5-b9d1-0b74e3a8513c ;
+    investigation:provenanceRecordAction ex:a73cd004-e283-5e9a-8cd1-a2e8833a2fba ;
+    uco-core:description "Evidence pointer: normalized.txt keypoints 50-52."@en .
+
+# --- OJJDP funding acknowledgment (keypoints 53-54) ---
+ex:7fc6a866-ab74-512d-bd5d-9c42c24e5e5b a uco-action:Action ;
+    rdfs:label "Page states OJJDP/DOJ funding acknowledgment and complementary transparency report"@en ;
+    uco-action:startTime "2026-07-19T05:03:58Z"^^xsd:dateTime ;
+    uco-action:performer ex:2f8ad703-8f71-5099-bf53-5c27da6bdc61 ;
+    uco-action:object ex:7e33c023-a82f-5fe5-b9d1-0b74e3a8513c ,
+                    ex:8e8e5deb-4049-5711-8730-152415db9c0b ,
+                    ex:3d9e6ca5-45e2-5a44-ad05-bbcdeb82f6dd ;
+    uco-core:description "Grounded in normalized.txt keypoints 53-54. Confidence: high. Site funded in part through OJJDP/OJP/DOJ grant; DOJ does not operate/control/endorse the website; complementary OJJDP transparency report noted."@en .
+
+ex:1175ab48-0a88-5d87-b5d0-0103f24b9641 a investigation:ProvenanceRecord ;
+    rdfs:label "Provenance: OJJDP/DOJ funding acknowledgment"@en ;
+    uco-core:object ex:7e33c023-a82f-5fe5-b9d1-0b74e3a8513c ;
+    investigation:provenanceRecordAction ex:7fc6a866-ab74-512d-bd5d-9c42c24e5e5b ;
+    uco-core:description "Evidence pointer: normalized.txt keypoints 53-54."@en .
+
+# =============================================================================
+# End of Path A example. Phase 3 skipped (no new TBox). Phase 5 SPARQL optional (not required for DoD).
+# C2.A3: Docker pySHACL Conforms True (core / us-ncmec / hotlines); ROBOT convert OK; integrity suite OK.
+# =============================================================================


### PR DESCRIPTION
## Summary

Adds a Path A example knowledge graph for NCMEC's **public** CyberTipline aggregate statistics page ([missingkids.org/cybertiplinedata](https://www.missingkids.org/cybertiplinedata)), plus the matching collected-source pack.

## What is included

- `examples_knowledge_graphs/ncmec-cybertipline-data-example.ttl` - reuse-only ABox example (no new classes or properties)
- `analytics_demonstration/collected_sources/ncmec-cybertipline-data/` - manifest, normalized keypoints, source extract, phase-0 guardrails, duplicate-detection report

## Design choices

- Public high-level aggregates only (program metrics, reporting flows, referrals, hash sharing, partnerships)
- Statement/listing Actions for aggregate counts rather than synthetic individual tip instances
- Provenance and evidence pointers grounded to `normalized.txt` keypoints
- No TBox changes

## Validation (local)

- Docker pySHACL: Conforms (core, us-ncmec, hotlines)
- ROBOT convert: OK
- Integrity suite: OK

## Test plan

- [ ] Review example TTL for spine alignment and provenance completeness
- [ ] Run project Docker validation suite (pySHACL + ROBOT) against the new example
- [ ] Confirm collected-source pack paths match evidence pointers in the TTL